### PR TITLE
Fix Windows compatibility in file path handling for JS output

### DIFF
--- a/scripts/archive/build-entities.js
+++ b/scripts/archive/build-entities.js
@@ -67,7 +67,9 @@ const output = project.emitToMemory();
 
 // Write emitted JS to outDir
 for (const outputFile of output.getFiles()) {
-  const filePath = path.join(outDir, outputFile.filePath);
+  // Fix for Windows: outputFile.filePath might be absolute, so use basename
+  const fileName = path.basename(outputFile.filePath);
+  const filePath = path.join(outDir, fileName);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, outputFile.text, 'utf8');
 }

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -459,7 +459,9 @@ async function compileEntitiesToJS(project: Project, outputDir: string) {
 
   // Write JS files to disk
   for (const outputFile of emitResult.getFiles()) {
-    const jsFilePath = path.join(outputDir, outputFile.filePath);
+    // Fix for Windows: outputFile.filePath might be absolute, so use basename
+    const fileName = path.basename(outputFile.filePath);
+    const jsFilePath = path.join(outputDir, fileName);
     const jsDir = path.dirname(jsFilePath);
 
     if (!fs.existsSync(jsDir)) {

--- a/src/core/database/entities/category.entity.ts
+++ b/src/core/database/entities/category.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Post } from './post.entity';
+
+@Entity('category')
+export class Category {
+    @PrimaryGeneratedColumn('increment')
+    id: number;
+    @Column({ type: "varchar", nullable: true })
+    name: string;
+    @ManyToMany('Post', (rel: any) => rel.categories, { nullable: true, cascade: true, onDelete: 'CASCADE', onUpdate: 'CASCADE' })
+    @JoinTable()
+    posts: any;
+    @CreateDateColumn()
+    createdAt: Date;
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/src/core/database/entities/post.entity.ts
+++ b/src/core/database/entities/post.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Category } from './category.entity';
+
+@Entity('post')
+export class Post {
+    @PrimaryGeneratedColumn('increment')
+    id: number;
+    @Column({ type: "varchar", nullable: true })
+    title: string;
+    @ManyToMany('Category', (rel: any) => rel.posts, { nullable: true, onDelete: 'CASCADE', onUpdate: 'CASCADE' })
+    categories: any;
+    @CreateDateColumn()
+    createdAt: Date;
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/src/modules/code-generation/utils/build-helper.ts
+++ b/src/modules/code-generation/utils/build-helper.ts
@@ -59,7 +59,9 @@ export async function buildTypeScriptToJs({
 
     // Write emitted JS files to output directory
     for (const outputFile of output.getFiles()) {
-      const outputPath = path.join(outDir, outputFile.filePath);
+      // Fix for Windows: outputFile.filePath might be absolute, so use basename
+      const fileName = path.basename(outputFile.filePath);
+      const outputPath = path.join(outDir, fileName);
       fs.mkdirSync(path.dirname(outputPath), { recursive: true });
       fs.writeFileSync(outputPath, outputFile.text, 'utf8');
     }


### PR DESCRIPTION
- Updated file path handling in init-db.ts, build-entities.js, and build-helper.ts to use basename for outputFile.filePath, ensuring compatibility with absolute paths on Windows.
- This change prevents potential issues when writing emitted JS files to disk across different operating systems.