### PR TITLE
feat: add password hashing functionality to /me route

### DIFF
--- a/src/core/bootstrap/data/init.json
+++ b/src/core/bootstrap/data/init.json
@@ -319,6 +319,14 @@
         },
         {
             "isEnabled": true,
+            "preHook": "if (@BODY.password) { @BODY.password = await @HELPERS.$bcrypt.hash(@BODY.password); }",
+            "name": "Me route hash password",
+            "isSystem":true,
+            "route": "/me",
+            "methods": ["PATCH"]
+        },
+        {
+            "isEnabled": true,
             "preHook": "if (@BODY.name) { @BODY.slug = await @HELPERS.autoSlug(@BODY.name); }",
             "name": "Folder definition auto slug",
             "isSystem": true,


### PR DESCRIPTION
- Introduced a new route for the /me endpoint that hashes the password in the request body before processing, enhancing security for user updates.
- The new route is enabled for PATCH requests and utilizes the bcrypt helper for password hashing.