### PR TITLE
refactor: enhance metadata cache service to support schema retrieval

### DIFF
--- a/src/infrastructure/cache/services/metadata-cache.service.ts
+++ b/src/infrastructure/cache/services/metadata-cache.service.ts
@@ -8,7 +8,6 @@ import { getJunctionTableName, getForeignKeyColumnName, getJunctionColumnNames }
 import { METADATA_CACHE_SYNC_EVENT_KEY, ENFYRA_ADMIN_WEBSOCKET_NAMESPACE } from '../../../shared/utils/constant';
 import { CACHE_EVENTS, CACHE_IDENTIFIERS, shouldReloadCache } from '../../../shared/utils/cache-events.constants';
 import { DynamicWebSocketGateway } from '../../../modules/websocket/gateway/dynamic-websocket.gateway';
-import { ObjectId } from 'mongodb';
 
 const COLOR = '\x1b[36m';
 const RESET = '\x1b[0m';
@@ -118,8 +117,37 @@ export class MetadataCacheService implements OnApplicationBootstrap, OnModuleIni
   private async loadMetadataFromDb(): Promise<EnfyraMetadata> {
     const isMongoDB = this.queryBuilder.isMongoDb();
 
-    const tablesResult = await this.queryBuilder.select({ tableName: 'table_definition' });
+    const [tablesResult, allColumnsResult, allRelationsResult] = await Promise.all([
+      this.queryBuilder.select({ tableName: 'table_definition' }),
+      this.queryBuilder.select({ tableName: 'column_definition' }),
+      this.queryBuilder.select({ tableName: 'relation_definition' }),
+    ]);
     const tables = tablesResult.data;
+
+    let allSchemas: Map<string, any> | null = null;
+    if (!isMongoDB) {
+      allSchemas = await this.databaseSchemaService.getAllTableSchemas();
+    }
+
+    const columnsByTable = new Map<string | number, any[]>();
+    for (const col of allColumnsResult.data) {
+      const key = isMongoDB ? String(col.table) : col.tableId;
+      if (!columnsByTable.has(key)) columnsByTable.set(key, []);
+      columnsByTable.get(key)!.push(col);
+    }
+
+    const relationsBySource = new Map<string | number, any[]>();
+    for (const rel of allRelationsResult.data) {
+      const key = isMongoDB ? String(rel.sourceTable) : rel.sourceTableId;
+      if (!relationsBySource.has(key)) relationsBySource.set(key, []);
+      relationsBySource.get(key)!.push(rel);
+    }
+
+    const tableIdToName = new Map<string | number, string>();
+    for (const t of tables) {
+      const id = isMongoDB ? String(t._id) : t.id;
+      tableIdToName.set(id, t.name);
+    }
 
     const tablesList: any[] = [];
     const tablesMap = new Map<string, any>();
@@ -128,7 +156,7 @@ export class MetadataCacheService implements OnApplicationBootstrap, OnModuleIni
       try {
         let actualSchema = null;
         if (!isMongoDB) {
-          actualSchema = await this.databaseSchemaService.getActualTableSchema(table.name);
+          actualSchema = allSchemas!.get(table.name);
           if (!actualSchema) {
             this.logger.warn(`Table ${table.name} not found in database, skipping...`);
             continue;
@@ -139,51 +167,32 @@ export class MetadataCacheService implements OnApplicationBootstrap, OnModuleIni
         let indexes = [];
         if (table.uniques) {
           if (typeof table.uniques === 'string') {
-            try {
-              uniques = JSON.parse(table.uniques);
-            } catch (e) {
-              this.logger.warn(`Failed to parse uniques for table ${table.name}`);
-            }
+            try { uniques = JSON.parse(table.uniques); } catch (e) { this.logger.warn(`Failed to parse uniques for table ${table.name}`); }
           } else if (Array.isArray(table.uniques)) {
             uniques = table.uniques;
           }
         }
         if (table.indexes) {
           if (typeof table.indexes === 'string') {
-            try {
-              indexes = JSON.parse(table.indexes);
-            } catch (e) {
-              this.logger.warn(`Failed to parse indexes for table ${table.name}`);
-            }
+            try { indexes = JSON.parse(table.indexes); } catch (e) { this.logger.warn(`Failed to parse indexes for table ${table.name}`); }
           } else if (Array.isArray(table.indexes)) {
             indexes = table.indexes;
           }
         }
 
-        const tableIdField = isMongoDB ? 'table' : 'tableId';
-        const tableIdValue = isMongoDB
-          ? (typeof table._id === 'string' ? new ObjectId(table._id) : table._id)
-          : table.id;
+        const tableIdValue = isMongoDB ? String(table._id) : table.id;
 
-        const columnsResult = await this.queryBuilder.select({
-          tableName: 'column_definition',
-          filter: { [tableIdField]: { _eq: tableIdValue } }
-        });
-        const explicitColumns = columnsResult.data;
+        const explicitColumns = columnsByTable.get(tableIdValue) || [];
 
         const parsedExplicitColumns = explicitColumns.map((col: any) => {
           const column = { ...col };
 
           if (col.options && typeof col.options === 'string') {
-            try {
-              column.options = JSON.parse(col.options);
-            } catch (e) {}
+            try { column.options = JSON.parse(col.options); } catch (e) {}
           }
 
           if (col.defaultValue && typeof col.defaultValue === 'string') {
-            try {
-              column.defaultValue = JSON.parse(col.defaultValue);
-            } catch (e) {}
+            try { column.defaultValue = JSON.parse(col.defaultValue); } catch (e) {}
           }
 
           const booleanFields = ['isPrimary', 'isGenerated', 'isNullable', 'isSystem', 'isUpdatable', 'isHidden'];
@@ -196,13 +205,7 @@ export class MetadataCacheService implements OnApplicationBootstrap, OnModuleIni
           return column;
         });
 
-        const sourceTableIdField = isMongoDB ? 'sourceTable' : 'sourceTableId';
-
-        const relationsResult = await this.queryBuilder.select({
-          tableName: 'relation_definition',
-          filter: { [sourceTableIdField]: { _eq: tableIdValue } }
-        });
-        const relationsData = relationsResult.data;
+        const relationsData = relationsBySource.get(tableIdValue) || [];
 
         const relations: any[] = [];
         for (const rel of relationsData) {
@@ -213,21 +216,13 @@ export class MetadataCacheService implements OnApplicationBootstrap, OnModuleIni
             }
           }
 
-          const targetTableIdField = isMongoDB ? '_id' : 'id';
-          const targetTableIdValue = isMongoDB
-            ? (typeof rel.targetTable === 'string' ? new ObjectId(rel.targetTable) : rel.targetTable)
-            : rel.targetTableId;
-
-          const targetTableResult = await this.queryBuilder.select({
-            tableName: 'table_definition',
-            filter: { [targetTableIdField]: { _eq: targetTableIdValue } }
-          });
-          const targetTable = targetTableResult.data;
+          const targetTableIdValue = isMongoDB ? String(rel.targetTable) : rel.targetTableId;
+          const targetTableName = tableIdToName.get(targetTableIdValue);
 
           const relationMetadata: any = {
             ...rel,
             sourceTableName: table.name,
-            targetTableName: targetTable[0]?.name || rel.targetTableName,
+            targetTableName: targetTableName || rel.targetTableName,
           };
 
           if (rel.type === 'one-to-many') {

--- a/src/infrastructure/knex/services/database-schema.service.ts
+++ b/src/infrastructure/knex/services/database-schema.service.ts
@@ -7,6 +7,92 @@ export class DatabaseSchemaService {
 
   constructor(private readonly knexService: KnexService) {}
 
+  async getAllTableSchemas(): Promise<Map<string, any>> {
+    const knex = this.knexService.getKnex();
+    const dbType = process.env.DB_TYPE;
+
+    if (dbType === 'mysql') {
+      return this.getAllMySQLTableSchemas(knex);
+    } else if (dbType === 'postgres') {
+      return this.getAllPostgreSQLTableSchemas(knex);
+    }
+    return new Map();
+  }
+
+  private async getAllMySQLTableSchemas(knex: any): Promise<Map<string, any>> {
+    const db = knex.client.database();
+    const [allTables, allColumns, allIndexes, allForeignKeys] = await Promise.all([
+      knex('INFORMATION_SCHEMA.TABLES').select('TABLE_NAME', 'TABLE_COMMENT').where('TABLE_SCHEMA', db),
+      knex('INFORMATION_SCHEMA.COLUMNS').select('TABLE_NAME', 'COLUMN_NAME as name', 'DATA_TYPE as type', 'IS_NULLABLE as isNullable', 'COLUMN_DEFAULT as defaultValue', 'COLUMN_KEY as columnKey', 'EXTRA as extra', 'COLUMN_COMMENT as description', 'CHARACTER_MAXIMUM_LENGTH as maxLength', 'NUMERIC_PRECISION as precision', 'NUMERIC_SCALE as scale').where('TABLE_SCHEMA', db).orderBy('ORDINAL_POSITION'),
+      knex('INFORMATION_SCHEMA.STATISTICS').select('TABLE_NAME', 'INDEX_NAME', 'COLUMN_NAME', 'NON_UNIQUE').where('TABLE_SCHEMA', db).where('INDEX_NAME', '!=', 'PRIMARY').orderBy('INDEX_NAME', 'SEQ_IN_INDEX'),
+      knex('INFORMATION_SCHEMA.KEY_COLUMN_USAGE').select('TABLE_NAME', 'COLUMN_NAME', 'REFERENCED_TABLE_NAME', 'REFERENCED_COLUMN_NAME', 'CONSTRAINT_NAME').where('TABLE_SCHEMA', db).whereNotNull('REFERENCED_TABLE_NAME'),
+    ]);
+
+    const result = new Map<string, any>();
+    const tableNames = new Set<string>(allTables.map((t: any) => t.TABLE_NAME));
+
+    for (const tableName of tableNames) {
+      const cols = allColumns.filter((c: any) => c.TABLE_NAME === tableName);
+      const transformedColumns = cols.map((col: any) => ({
+        name: col.name, type: this.mapMySQLDataType(col.type, col), isPrimary: col.columnKey === 'PRI',
+        isGenerated: col.extra?.includes('auto_increment') || false, isNullable: col.isNullable === 'YES',
+        isSystem: this.isSystemColumn(col.name), isUpdatable: !col.extra?.includes('auto_increment'),
+        isHidden: false, defaultValue: col.defaultValue, description: col.description,
+        options: { length: col.maxLength, precision: col.precision, scale: col.scale },
+      }));
+
+      const idxs = allIndexes.filter((i: any) => i.TABLE_NAME === tableName);
+      const indexGroups = this.groupMySQLIndexes(idxs);
+
+      const fks = allForeignKeys.filter((f: any) => f.TABLE_NAME === tableName);
+      const relations = this.transformForeignKeysToRelations(fks);
+
+      result.set(tableName, { name: tableName, isSystem: false, uniques: indexGroups.uniques, indexes: indexGroups.indexes, columns: transformedColumns, relations });
+    }
+    return result;
+  }
+
+  private async getAllPostgreSQLTableSchemas(knex: any): Promise<Map<string, any>> {
+    const [allTables, allColumns, allPrimaryKeys, allIndexes] = await Promise.all([
+      knex('information_schema.tables').select('table_name').where('table_schema', 'public'),
+      knex('information_schema.columns').select('table_name', 'column_name as name', 'data_type as type', 'is_nullable as isNullable', 'column_default as defaultValue', 'character_maximum_length as maxLength', 'numeric_precision as precision', 'numeric_scale as scale').where('table_schema', 'public').orderBy('ordinal_position'),
+      knex('information_schema.table_constraints').join('information_schema.key_column_usage', function() { this.on('table_constraints.constraint_name', '=', 'key_column_usage.constraint_name').andOn('table_constraints.table_schema', '=', 'key_column_usage.table_schema'); }).select('table_constraints.table_name', 'key_column_usage.column_name').where('table_constraints.table_schema', 'public').where('table_constraints.constraint_type', 'PRIMARY KEY'),
+      knex('pg_indexes').select('tablename', 'indexname', 'indexdef').where('schemaname', 'public'),
+    ]);
+
+    const result = new Map<string, any>();
+    const tableNames = new Set<string>(allTables.map((t: any) => t.table_name));
+
+    for (const tableName of tableNames) {
+      const cols = allColumns.filter((c: any) => c.table_name === tableName);
+      const pks = new Set(allPrimaryKeys.filter((p: any) => p.table_name === tableName).map((p: any) => p.column_name));
+
+      const transformedColumns = cols.map((col: any) => ({
+        name: col.name, type: this.mapPostgreSQLDataType(col.type, col),
+        isPrimary: pks.has(col.name), isGenerated: col.defaultValue?.includes('nextval') || false,
+        isNullable: col.isNullable === 'YES', isSystem: this.isSystemColumn(col.name),
+        isUpdatable: true, isHidden: false, defaultValue: col.defaultValue, description: null,
+        options: { length: col.maxLength, precision: col.precision, scale: col.scale },
+      }));
+
+      const idxs = allIndexes.filter((i: any) => i.tablename === tableName);
+      const uniques: string[][] = [];
+      const regularIndexes: string[][] = [];
+      for (const idx of idxs) {
+        if (idx.indexname.endsWith('_pkey') || idx.indexname === `pk_${tableName}`) continue;
+        const isUnique = idx.indexdef?.includes('UNIQUE') || idx.indexname.includes('_unique');
+        const columnsMatch = idx.indexdef?.match(/\(([^)]+)\)/);
+        if (columnsMatch) {
+          const columns = columnsMatch[1].split(',').map((c: string) => c.trim().replace(/"/g, ''));
+          if (isUnique) uniques.push(columns); else regularIndexes.push(columns);
+        }
+      }
+
+      result.set(tableName, { name: tableName, isSystem: false, uniques, indexes: regularIndexes, columns: transformedColumns, relations: [] });
+    }
+    return result;
+  }
+
   async getActualTableSchema(tableName: string): Promise<any> {
     const knex = this.knexService.getKnex();
     const dbType = process.env.DB_TYPE || 'mysql';


### PR DESCRIPTION
- Updated the MetadataCacheService to load metadata from the database more efficiently by using Promise.all for concurrent queries.
- Introduced a new method in DatabaseSchemaService to retrieve all table schemas for both MySQL and PostgreSQL databases.
- Improved handling of columns and relations by utilizing maps for better performance and clarity.
- Removed redundant MongoDB checks and streamlined the logic for fetching table schemas and relations.