### PR TITLE
feat: enhance dynamic repository to include needsPostSql flag

### DIFF
--- a/src/modules/dynamic-api/repositories/dynamic.repository.ts
+++ b/src/modules/dynamic-api/repositories/dynamic.repository.ts
@@ -227,16 +227,18 @@ export class DynamicRepository {
     tableName: string,
     fields: string | string[] | undefined,
     deep: Record<string, any> | undefined,
-  ): Promise<{ fields: string | string[] | undefined; deep: Record<string, any> | undefined }> {
+  ): Promise<{ fields: string | string[] | undefined; deep: Record<string, any> | undefined; needsPostSql: boolean }> {
     if (!this.enforceFieldPermission || !this.fieldPermissionCacheService) {
-      return { fields, deep };
+      return { fields, deep, needsPostSql: false };
     }
     if (this.context?.$user?.isRootAdmin) {
-      return { fields, deep };
+      return { fields, deep, needsPostSql: false };
     }
 
     const meta = await this.metadataCacheService.lookupTableByName(tableName);
-    if (!meta) return { fields, deep };
+    if (!meta) return { fields, deep, needsPostSql: false };
+
+    let hasConditionalPending = false;
 
     const columnSet = new Set<string>(
       (meta.columns || []).map((c: any) => c.name as string),
@@ -297,6 +299,7 @@ export class DynamicRepository {
         } else {
           const hasConditional = await this.hasConditionalRulesForField(tableName, 'read', 'column', colName);
           if (!hasConditional) deniedColumns.add(colName);
+          else hasConditionalPending = true;
         }
       }
     }
@@ -323,6 +326,7 @@ export class DynamicRepository {
         } else {
           const hasConditional = await this.hasConditionalRulesForField(tableName, 'read', 'relation', relName);
           if (!hasConditional) deniedRelations.add(relName);
+          else hasConditionalPending = true;
         }
       }
     }
@@ -352,21 +356,23 @@ export class DynamicRepository {
         const relMeta = (meta.relations || []).find(
           (r: any) => r.propertyName === relName,
         );
-        if (!relMeta?.targetTable) continue;
-        const { fields: nf, deep: nd } = await this.stripDeniedFields(
-          relMeta.targetTable,
+        const targetTable = relMeta?.targetTable || relMeta?.targetTableName;
+        if (!targetTable) continue;
+        const nested = await this.stripDeniedFields(
+          targetTable,
           relEntry.fields,
           relEntry.deep,
         );
+        if (nested.needsPostSql) hasConditionalPending = true;
         cleanDeep[relName] = {
           ...relEntry,
-          ...(nf !== relEntry.fields ? { fields: nf } : {}),
-          ...(nd !== relEntry.deep ? { deep: nd } : {}),
+          ...(nested.fields !== relEntry.fields ? { fields: nested.fields } : {}),
+          ...(nested.deep !== relEntry.deep ? { deep: nested.deep } : {}),
         };
       }
     }
 
-    return { fields: cleanFields, deep: cleanDeep };
+    return { fields: cleanFields, deep: cleanDeep, needsPostSql: hasConditionalPending };
   }
 
   async find(
@@ -384,7 +390,7 @@ export class DynamicRepository {
 
     const rawFields = opt?.fields || this.context.$query?.fields;
     const rawDeep: Record<string, any> = this.context.$query?.deep || {};
-    const { fields: cleanFields, deep: cleanDeep } = await this.stripDeniedFields(
+    const { fields: cleanFields, deep: cleanDeep, needsPostSql } = await this.stripDeniedFields(
       this.tableName,
       rawFields,
       rawDeep,
@@ -410,10 +416,7 @@ export class DynamicRepository {
       maxQueryDepth: this.settingCacheService.getMaxQueryDepth(),
     } as any);
 
-    if (!this.enforceFieldPermission || !this.fieldPermissionCacheService) {
-      return result;
-    }
-    if (this.context?.$user?.isRootAdmin) {
+    if (!needsPostSql) {
       return result;
     }
 

--- a/test/security/is-published-field-permission.spec.ts
+++ b/test/security/is-published-field-permission.spec.ts
@@ -60,10 +60,36 @@ function makeRepoHarness(opts: {
   const tableName = opts.tableMeta.name;
 
   const queryEngine = {
-    find: jest.fn(async () => ({
-      data: opts.dataFixture ?? [],
-      meta: { totalCount: (opts.dataFixture ?? []).length },
-    })),
+    find: jest.fn(async (findOpts: any) => {
+      let data = JSON.parse(JSON.stringify(opts.dataFixture ?? []));
+      const f = findOpts?.fields;
+      if (f && f !== '' && f !== '*') {
+        const allowed = new Set(String(f).split(',').map((s: string) => s.split('.')[0].trim()));
+        data = data.map((row: any) => {
+          const out: any = {};
+          for (const key of Object.keys(row)) {
+            if (allowed.has(key)) out[key] = row[key];
+          }
+          return out;
+        });
+      }
+      const deepOpts = findOpts?.deep;
+      if (deepOpts && typeof deepOpts === 'object') {
+        for (const row of data) {
+          for (const relName of Object.keys(deepOpts)) {
+            if (!row[relName] || !deepOpts[relName]?.fields) continue;
+            const relFields = new Set(String(deepOpts[relName].fields).split(',').map((s: string) => s.trim()));
+            const nested = row[relName];
+            if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+              const cleaned: any = {};
+              for (const k of Object.keys(nested)) { if (relFields.has(k)) cleaned[k] = nested[k]; }
+              row[relName] = cleaned;
+            }
+          }
+        }
+      }
+      return { data, meta: { totalCount: (opts.dataFixture ?? []).length } };
+    }),
   } as any;
 
   const metadataCacheService = {
@@ -149,7 +175,9 @@ describe('field permissions (isPublished baseline + overrides)', () => {
   }
 
   function withMetadataMap(h: any) {
-    h.metadataCacheService.getDirectMetadata = jest.fn(() => makeMetadataMap());
+    const map = makeMetadataMap();
+    h.metadataCacheService.getDirectMetadata = jest.fn(() => map);
+    h.metadataCacheService.lookupTableByName = jest.fn(async (name: string) => map.tables.get(name) || null);
     return h;
   }
 

--- a/test/shared/body-parser-middleware.spec.ts
+++ b/test/shared/body-parser-middleware.spec.ts
@@ -1,0 +1,107 @@
+import { BodyParserMiddleware } from '../../src/shared/middleware/body-parser.middleware';
+
+function makeMiddleware(maxMB = 1) {
+  const settingCache = {
+    getMaxRequestBodySizeBytes: () => maxMB * 1024 * 1024,
+  } as any;
+  return new BodyParserMiddleware(settingCache);
+}
+
+function makeReq(overrides: any = {}): any {
+  return {
+    headers: {},
+    method: 'POST',
+    ...overrides,
+  };
+}
+
+function makeRes(): any {
+  const res: any = { statusCode: 200 };
+  res.status = (code: number) => { res.statusCode = code; return res; };
+  res.json = (body: any) => { res.body = body; return res; };
+  res.end = () => res;
+  res.setHeader = () => res;
+  res.getHeader = () => undefined;
+  return res;
+}
+
+describe('BodyParserMiddleware', () => {
+  it('skips multipart requests', () => {
+    const mw = makeMiddleware();
+    const next = jest.fn();
+    mw.use(makeReq({ headers: { 'content-type': 'multipart/form-data; boundary=---' } }), makeRes(), next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('skips unknown content types', () => {
+    const mw = makeMiddleware();
+    const next = jest.fn();
+    mw.use(makeReq({ headers: { 'content-type': 'text/plain' } }), makeRes(), next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('skips when no content-type header', () => {
+    const mw = makeMiddleware();
+    const next = jest.fn();
+    mw.use(makeReq({ headers: {} }), makeRes(), next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('parses JSON body within limit', (done) => {
+    const mw = makeMiddleware(1);
+    const body = JSON.stringify({ key: 'value' });
+    const { Readable } = require('stream');
+    const req = Object.assign(new Readable({ read() { this.push(body); this.push(null); } }), {
+      headers: { 'content-type': 'application/json', 'content-length': String(body.length) },
+      method: 'POST',
+    });
+    mw.use(req as any, makeRes(), (err?: any) => {
+      expect(err).toBeUndefined();
+      expect((req as any).body).toEqual({ key: 'value' });
+      done();
+    });
+  });
+
+  it('rejects JSON body over limit', (done) => {
+    const mw = makeMiddleware(0.0001);
+    const body = JSON.stringify({ data: 'x'.repeat(1000) });
+    const { Readable } = require('stream');
+    const req = Object.assign(new Readable({ read() { this.push(body); this.push(null); } }), {
+      headers: { 'content-type': 'application/json', 'content-length': String(body.length) },
+      method: 'POST',
+    });
+    mw.use(req as any, makeRes(), (err?: any) => {
+      expect(err).toBeDefined();
+      expect(err.type).toBe('entity.too.large');
+      done();
+    });
+  });
+
+  it('reads limit dynamically per request', (done) => {
+    let currentLimit = 1;
+    const settingCache = {
+      getMaxRequestBodySizeBytes: () => currentLimit * 1024 * 1024,
+    } as any;
+    const mw = new BodyParserMiddleware(settingCache);
+    const bigBody = JSON.stringify({ data: 'x'.repeat(2000) });
+    const smallBody = JSON.stringify({ ok: true });
+    const { Readable } = require('stream');
+
+    currentLimit = 0.0001;
+    const req1 = Object.assign(new Readable({ read() { this.push(bigBody); this.push(null); } }), {
+      headers: { 'content-type': 'application/json', 'content-length': String(bigBody.length) },
+    });
+    mw.use(req1 as any, makeRes(), (err?: any) => {
+      expect(err).toBeDefined();
+
+      currentLimit = 10;
+      const req2 = Object.assign(new Readable({ read() { this.push(smallBody); this.push(null); } }), {
+        headers: { 'content-type': 'application/json', 'content-length': String(smallBody.length) },
+      });
+      mw.use(req2 as any, makeRes(), (err2?: any) => {
+        expect(err2).toBeUndefined();
+        done();
+      });
+    });
+  });
+});

--- a/test/shared/strip-denied-relations.spec.ts
+++ b/test/shared/strip-denied-relations.spec.ts
@@ -302,6 +302,51 @@ describe('stripDeniedFields — wildcard resolution', () => {
   });
 });
 
+function makeConditionalRelAllowPolicy(tableName: string, relName: string) {
+  return {
+    unconditionalAllowedColumns: new Set<string>(),
+    unconditionalAllowedRelations: new Set<string>(),
+    unconditionalDeniedColumns: new Set<string>(),
+    unconditionalDeniedRelations: new Set<string>(),
+    rules: [
+      {
+        id: 1,
+        isEnabled: true,
+        action: 'read' as const,
+        effect: 'allow' as const,
+        tableName,
+        roleId: null,
+        allowedUserIds: [],
+        columnName: null,
+        relationPropertyName: relName,
+        condition: { owner: { _eq: '@USER.id' } },
+      },
+    ],
+  };
+}
+
+const TABLE_META_UNPUBLISHED_REL: Record<string, any> = {
+  ...TABLE_META,
+  main_table: {
+    ...TABLE_META.main_table,
+    relations: [
+      ...TABLE_META.main_table.relations,
+      { propertyName: 'secretRel', targetTable: 'company_table', isPublished: false },
+    ],
+  },
+};
+
+const TABLE_META_NESTED_CONDITIONAL: Record<string, any> = {
+  ...TABLE_META,
+  user_table: {
+    ...TABLE_META.user_table,
+    columns: [
+      ...TABLE_META.user_table.columns,
+      { name: 'salary', isPublished: false },
+    ],
+  },
+};
+
 describe('stripDeniedFields — conditional rules safety', () => {
   it('does NOT strip isPublished:false column when conditional allow rule exists', async () => {
     const repo = makeRepo({
@@ -309,12 +354,89 @@ describe('stripDeniedFields — conditional rules safety', () => {
     });
     const result = await strip(repo, 'main_table', ['id', 'name', 'secret'], undefined);
     expect(result.fields).toEqual(['id', 'name', 'secret']);
+    expect(result.needsPostSql).toBe(true);
   });
 
   it('strips isPublished:false column when no conditional rules exist', async () => {
     const repo = makeRepo();
     const result = await strip(repo, 'main_table', ['id', 'name', 'secret'], undefined);
     expect(result.fields).toEqual(['id', 'name']);
+    expect(result.needsPostSql).toBe(false);
+  });
+
+  it('does NOT strip isPublished:false relation when conditional allow rule exists', async () => {
+    const repo = makeRepo({
+      tableMetaMap: TABLE_META_UNPUBLISHED_REL,
+      policiesMap: { 'main_table:read': [makeConditionalRelAllowPolicy('main_table', 'secretRel')] },
+    });
+    const result = await strip(repo, 'main_table', ['id', 'secretRel'], { secretRel: {} });
+    expect(String(result.fields)).toContain('secretRel');
+    expect(result.deep).toHaveProperty('secretRel');
+    expect(result.needsPostSql).toBe(true);
+  });
+
+  it('strips isPublished:false relation when no conditional rules exist', async () => {
+    const repo = makeRepo({ tableMetaMap: TABLE_META_UNPUBLISHED_REL });
+    const result = await strip(repo, 'main_table', ['id', 'secretRel'], { secretRel: {} });
+    expect(String(result.fields)).not.toContain('secretRel');
+    expect(result.deep).not.toHaveProperty('secretRel');
+    expect(result.needsPostSql).toBe(false);
+  });
+
+  it('needsPostSql bubbles up from nested deep', async () => {
+    const repo = makeRepo({
+      tableMetaMap: TABLE_META_NESTED_CONDITIONAL,
+      policiesMap: { 'user_table:read': [makeConditionalAllowPolicy('user_table', 'salary')] },
+    });
+    const deep = { author: { fields: ['id', 'salary'], deep: {} } };
+    const result = await strip(repo, 'main_table', ['id', 'author'], deep);
+    expect(result.needsPostSql).toBe(true);
+  });
+
+  it('needsPostSql is false when nested deep has no conditional rules', async () => {
+    const repo = makeRepo();
+    const deep = { author: { fields: ['id', 'email'], deep: {} } };
+    const result = await strip(repo, 'main_table', ['id', 'author'], deep);
+    expect(result.needsPostSql).toBe(false);
+  });
+});
+
+describe('hasConditionalRulesForField — direct', () => {
+  it('returns true when conditional rule matches field', async () => {
+    const repo = makeRepo({
+      policiesMap: { 'main_table:read': [makeConditionalAllowPolicy('main_table', 'secret')] },
+    });
+    const result = await (repo as any).hasConditionalRulesForField('main_table', 'read', 'column', 'secret');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when no conditional rules for field', async () => {
+    const repo = makeRepo({
+      policiesMap: { 'main_table:read': [makeColDenyPolicy('main_table', 'name')] },
+    });
+    const result = await (repo as any).hasConditionalRulesForField('main_table', 'read', 'column', 'name');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when no policies at all', async () => {
+    const repo = makeRepo();
+    const result = await (repo as any).hasConditionalRulesForField('main_table', 'read', 'column', 'name');
+    expect(result).toBe(false);
+  });
+
+  it('returns true for conditional relation rule', async () => {
+    const repo = makeRepo({
+      policiesMap: { 'main_table:read': [makeConditionalRelAllowPolicy('main_table', 'author')] },
+    });
+    const result = await (repo as any).hasConditionalRulesForField('main_table', 'read', 'relation', 'author');
+    expect(result).toBe(true);
+  });
+
+  it('returns false for fieldPermissionCacheService not set', async () => {
+    const repo = makeRepo();
+    repo.fieldPermissionCacheService = undefined;
+    const result = await (repo as any).hasConditionalRulesForField('main_table', 'read', 'column', 'secret');
+    expect(result).toBe(false);
   });
 });
 
@@ -384,20 +506,36 @@ describe('DynamicRepository.find — stripDeniedFields integration', () => {
     expect(fields).not.toContain('secret');
   });
 
-  it('sanitizeFieldPermissionsResult still runs as safety net', async () => {
+  it('post-SQL runs only when conditional rules exist', async () => {
     const repo = makeFullRepo({
-      queryEngineResult: { data: [{ id: 1 }], count: 1 },
+      policiesMap: { 'main_table:read': [makeConditionalAllowPolicy('main_table', 'secret')] },
+      queryEngineResult: { data: [{ id: 1, secret: 'x' }], count: 1 },
     });
-    repo.context.$query.fields = ['id'];
-    const sanitizeSpy = jest
-      .spyOn(
-        require('../../src/shared/utils/sanitize-field-permissions.util'),
-        'sanitizeFieldPermissionsResult',
-      )
-      .mockResolvedValue([{ id: 1 }]);
-    const result = await repo.find({});
+    repo.context.$query.fields = ['id', 'secret'];
+    repo.metadataCacheService.getDirectMetadata = jest.fn().mockReturnValue({
+      tables: new Map(Object.entries(TABLE_META)),
+      tablesList: Object.values(TABLE_META),
+    });
+    const sanitizeSpy = jest.spyOn(
+      require('../../src/shared/utils/sanitize-field-permissions.util'),
+      'sanitizeFieldPermissionsResult',
+    ).mockResolvedValue([{ id: 1 }]);
+    await repo.find({});
     expect(sanitizeSpy).toHaveBeenCalled();
-    expect(result.data).toEqual([{ id: 1 }]);
+    sanitizeSpy.mockRestore();
+  });
+
+  it('post-SQL skipped when no conditional rules (all resolved pre-SQL)', async () => {
+    const repo = makeFullRepo({
+      queryEngineResult: { data: [{ id: 1, name: 'test' }], count: 1 },
+    });
+    repo.context.$query.fields = ['id', 'name'];
+    const sanitizeSpy = jest.spyOn(
+      require('../../src/shared/utils/sanitize-field-permissions.util'),
+      'sanitizeFieldPermissionsResult',
+    );
+    await repo.find({});
+    expect(sanitizeSpy).not.toHaveBeenCalled();
     sanitizeSpy.mockRestore();
   });
 });


### PR DESCRIPTION
- Updated the stripDeniedFields method to return a needsPostSql boolean indicating if post-SQL processing is required.
- Adjusted logic to handle conditional rules for fields and relations, setting needsPostSql accordingly.
- Modified the find method to utilize the new needsPostSql flag for query optimization.