### PR TITLE
chore: update package version and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.1.7-patch-1",
+  "version": "2.1.7-patch-2",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "private": false,
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1024.0",
-    "@enfyra/kernel": "1.0.9",
+    "@enfyra/kernel": "1.0.10",
     "@envelop/depth-limit": "^7.1.1",
     "@google-cloud/storage": "^7.19.0",
     "@graphql-tools/schema": "^10.0.31",

--- a/test/domain/script-code.util.spec.ts
+++ b/test/domain/script-code.util.spec.ts
@@ -2,6 +2,7 @@ import {
   compileScriptSource,
   getExecutableScript,
   normalizeFlowStepScriptConfig,
+  normalizeScriptPatch,
   normalizeScriptRecord,
   resolveExecutableScript,
 } from '@enfyra/kernel';
@@ -75,5 +76,75 @@ describe('script-code util', () => {
     expect(resolved.code).toContain('const value = $ctx.$body.name;');
     expect(resolved.compiledCode).toBe(resolved.code);
     expect(resolved.shouldPersistCompiledCode).toBe(true);
+  });
+
+  it('normalizes legacy code patches without mutating the patch object', () => {
+    const patch = {
+      code: 'const value: string = @BODY.name; return value;',
+    };
+    const normalized = normalizeScriptPatch('pre_hook_definition', patch);
+
+    expect(patch).toEqual({
+      code: 'const value: string = @BODY.name; return value;',
+    });
+    expect(normalized.code).toBeUndefined();
+    expect(normalized.sourceCode).toBe(
+      'const value: string = @BODY.name; return value;',
+    );
+    expect(normalized.scriptLanguage).toBe('typescript');
+    expect(normalized.compiledCode).toContain(
+      'const value = $ctx.$body.name;',
+    );
+  });
+
+  it('recompiles from existing source when only scriptLanguage is patched', () => {
+    const normalized = normalizeScriptPatch(
+      'route_handler_definition',
+      { scriptLanguage: 'javascript' },
+      {
+        sourceCode: 'return @BODY.name;',
+        compiledCode: 'stale',
+        scriptLanguage: 'typescript',
+      },
+    );
+
+    expect(normalized.sourceCode).toBeUndefined();
+    expect(normalized.scriptLanguage).toBe('javascript');
+    expect(normalized.compiledCode).toBe('return $ctx.$body.name;');
+  });
+
+  it('clears compiled code when source is explicitly cleared', () => {
+    const normalized = normalizeScriptPatch(
+      'post_hook_definition',
+      { sourceCode: null },
+      {
+        sourceCode: 'return @BODY.name;',
+        compiledCode: 'return $ctx.$body.name;',
+        scriptLanguage: 'typescript',
+      },
+    );
+
+    expect(normalized.sourceCode).toBeNull();
+    expect(normalized.compiledCode).toBeNull();
+  });
+
+  it('does not rewrite invalid JSON flow configs', () => {
+    const record = { type: 'script', config: '{broken json' };
+    expect(normalizeFlowStepScriptConfig(record)).toBe(record);
+  });
+
+  it('normalizes JSON string flow configs and removes legacy code', () => {
+    const normalized = normalizeFlowStepScriptConfig({
+      type: 'condition',
+      config: JSON.stringify({
+        code: 'const ok: boolean = @BODY.enabled; return ok;',
+      }),
+    });
+
+    expect(typeof normalized.config).toBe('string');
+    const config = JSON.parse(normalized.config);
+    expect(config.code).toBeUndefined();
+    expect(config.sourceCode).toContain('@BODY.enabled');
+    expect(config.compiledCode).toContain('$ctx.$body.enabled');
   });
 });

--- a/test/kernel/kernel-adversarial.spec.ts
+++ b/test/kernel/kernel-adversarial.spec.ts
@@ -1,0 +1,124 @@
+import {
+  CHUNKED_FETCH_CONCURRENCY,
+  WHERE_IN_CHUNK_SIZE,
+  chunkedFetch,
+  parseBatchFields,
+  perParentRun,
+} from '@enfyra/kernel';
+
+describe('kernel batch utilities adversarial behavior', () => {
+  test('chunkedFetch preserves input chunk order even when chunks finish out of order', async () => {
+    const values = Array.from(
+      { length: WHERE_IN_CHUNK_SIZE * 2 + 37 },
+      (_, index) => index,
+    );
+    const seenChunks: number[][] = [];
+
+    const result = await chunkedFetch(values, async (chunk: number[]) => {
+      seenChunks.push(chunk);
+      const chunkIndex = Math.floor(chunk[0] / WHERE_IN_CHUNK_SIZE);
+      await new Promise((resolve) =>
+        setTimeout(resolve, chunkIndex === 0 ? 20 : 1),
+      );
+      return chunk.map((value) => value * 2);
+    });
+
+    expect(seenChunks).toHaveLength(3);
+    expect(result).toEqual(values.map((value) => value * 2));
+  });
+
+  test('chunkedFetch limits concurrent chunk fetches', async () => {
+    const values = Array.from(
+      { length: WHERE_IN_CHUNK_SIZE * 6 + 1 },
+      (_, index) => index,
+    );
+    let active = 0;
+    let maxActive = 0;
+
+    await chunkedFetch(values, async (chunk: number[]) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return chunk;
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(CHUNKED_FETCH_CONCURRENCY);
+    expect(maxActive).toBeGreaterThan(1);
+  });
+
+  test('chunkedFetch propagates fetch errors instead of returning partial data', async () => {
+    const values = Array.from(
+      { length: WHERE_IN_CHUNK_SIZE + 1 },
+      (_, index) => index,
+    );
+
+    await expect(
+      chunkedFetch(values, async (chunk: number[]) => {
+        if (chunk[0] >= WHERE_IN_CHUNK_SIZE) {
+          throw new Error('chunk failed');
+        }
+        return chunk;
+      }),
+    ).rejects.toThrow('chunk failed');
+  });
+
+  test('perParentRun limits concurrency and maps results by parent id string', async () => {
+    const parentIds = Array.from({ length: 25 }, (_, index) => index + 1);
+    let active = 0;
+    let maxActive = 0;
+
+    const result = await perParentRun(
+      parentIds,
+      async (id: number) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 3));
+        active -= 1;
+        return id * 10;
+      },
+      4,
+    );
+
+    expect(maxActive).toBeLessThanOrEqual(4);
+    expect(result.size).toBe(parentIds.length);
+    expect(result.get('1')).toBe(10);
+    expect(result.get('25')).toBe(250);
+  });
+
+  test('perParentRun returns an empty map without calling the worker for empty input', async () => {
+    let called = false;
+    const result = await perParentRun(
+      [],
+      async () => {
+        called = true;
+        return 1;
+      },
+      4,
+    );
+
+    expect(called).toBe(false);
+    expect(result.size).toBe(0);
+  });
+
+  test('parseBatchFields keeps root wildcards and groups nested paths by first relation', () => {
+    const parsed = parseBatchFields([
+      '*',
+      'id',
+      'author.name',
+      'author.company.name',
+      'comments.body',
+      'comments.author.name',
+    ]);
+
+    expect(parsed.rootFields).toEqual(['*', 'id']);
+    expect(parsed.subRelations.get('author')).toEqual([
+      'name',
+      'company.name',
+    ]);
+    expect(parsed.subRelations.get('comments')).toEqual([
+      'body',
+      'author.name',
+    ]);
+  });
+});

--- a/test/package-management/package-runtime-child.spec.ts
+++ b/test/package-management/package-runtime-child.spec.ts
@@ -1,12 +1,13 @@
 import { fork } from 'child_process';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { createRequire } from 'module';
 import { tmpdir } from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { IsolatedExecutorService } from '@enfyra/kernel';
 
-const workerPath = path.resolve(
-  __dirname,
+const require = createRequire(import.meta.url);
+const workerPath = require.resolve(
   '@enfyra/kernel/execution/package-runtime.child.js',
 );
 
@@ -29,6 +30,7 @@ function callRuntime(child: ReturnType<typeof fork>, message: any) {
       clearTimeout(timeout);
       child.off('message', onMessage);
       child.off('error', onError);
+      child.off('exit', onExit);
     };
     const onMessage = (response: any) => {
       if (response.id !== message.id) return;
@@ -39,8 +41,19 @@ function callRuntime(child: ReturnType<typeof fork>, message: any) {
       cleanup();
       reject(error);
     };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `package runtime exited before response${
+            signal ? ` with signal ${signal}` : ` with code ${code}`
+          }`,
+        ),
+      );
+    };
     child.on('message', onMessage);
     child.on('error', onError);
+    child.on('exit', onExit);
     child.send(message);
   });
 }

--- a/test/query-builder/deep-dotted-sort-mongo.spec.ts
+++ b/test/query-builder/deep-dotted-sort-mongo.spec.ts
@@ -179,8 +179,8 @@ function makePosts(ids: ObjectId[]) {
   }));
 }
 
-describe('Mongo dotted sort on o2m (aggregate path)', () => {
-  test('sort comments ASC by author.name within each post', async () => {
+describe('Mongo dotted sort on o2m', () => {
+  test('rejects comments sort ASC by author.name', async () => {
     const rows = makePosts(postIds);
     const desc: MongoBatchFetchDescriptor = {
       relationName: 'comments',
@@ -192,23 +192,21 @@ describe('Mongo dotted sort on o2m (aggregate path)', () => {
       foreignField: 'post',
       userSort: 'author.name',
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-    );
-    const post0Bodies = rows[0].comments.map((c: any) => c.body);
-    const post1Bodies = rows[1].comments.map((c: any) => c.body);
-    expect(post0Bodies).toEqual(['c1', 'c0', 'c2']);
-    expect(post1Bodies).toEqual(['c5', 'c4', 'c3']);
+    await expect(
+      executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+      ),
+    ).rejects.toThrow(/Sort field 'author\.name' is not supported/i);
   });
 
-  test('sort comments DESC by author.name within each post', async () => {
+  test('rejects comments sort DESC by author.name', async () => {
     const rows = makePosts(postIds);
     const desc: MongoBatchFetchDescriptor = {
       relationName: 'comments',
@@ -220,29 +218,21 @@ describe('Mongo dotted sort on o2m (aggregate path)', () => {
       foreignField: 'post',
       userSort: '-author.name',
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-    );
-    expect(rows[0].comments.map((c: any) => c.body)).toEqual([
-      'c2',
-      'c0',
-      'c1',
-    ]);
-    expect(rows[1].comments.map((c: any) => c.body)).toEqual([
-      'c3',
-      'c4',
-      'c5',
-    ]);
+    await expect(
+      executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+      ),
+    ).rejects.toThrow(/Sort field 'author\.name' is not supported/i);
   });
 
-  test('dotted sort + limit per-parent returns top-k by sort key', async () => {
+  test('rejects dotted sort + limit per-parent', async () => {
     const rows = makePosts(postIds);
     const desc: MongoBatchFetchDescriptor = {
       relationName: 'comments',
@@ -255,23 +245,21 @@ describe('Mongo dotted sort on o2m (aggregate path)', () => {
       userSort: 'author.name',
       userLimit: 2,
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-    );
-    expect(rows[0].comments.length).toBe(2);
-    expect(rows[0].comments.map((c: any) => c.body)).toEqual(['c1', 'c0']);
-    expect(rows[1].comments.length).toBe(2);
-    expect(rows[1].comments.map((c: any) => c.body)).toEqual(['c5', 'c4']);
+    await expect(
+      executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+      ),
+    ).rejects.toThrow(/Sort field 'author\.name' is not supported/i);
   });
 
-  test('2-hop dotted sort: author.company.name', async () => {
+  test('rejects 2-hop dotted sort: author.company.name', async () => {
     const rows = makePosts(postIds);
     const desc: MongoBatchFetchDescriptor = {
       relationName: 'comments',
@@ -283,22 +271,21 @@ describe('Mongo dotted sort on o2m (aggregate path)', () => {
       foreignField: 'post',
       userSort: 'author.company.name',
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-    );
-    const post0Bodies = rows[0].comments.map((c: any) => c.body);
-    expect(post0Bodies[0] === 'c1' || post0Bodies[0] === 'c2').toBe(true);
-    expect(post0Bodies[post0Bodies.length - 1]).toBe('c0');
+    await expect(
+      executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+      ),
+    ).rejects.toThrow(/Sort field 'author\.company\.name' is not supported/i);
   });
 
-  test('dotted sort + filter combined (filter applied after join)', async () => {
+  test('rejects dotted sort + filter combined', async () => {
     const rows = makePosts([postIds[0]]);
     const desc: MongoBatchFetchDescriptor = {
       relationName: 'comments',
@@ -311,21 +298,21 @@ describe('Mongo dotted sort on o2m (aggregate path)', () => {
       userFilter: { seq: { _gte: 2 } },
       userSort: 'author.name',
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-    );
-    const bodies = rows[0].comments.map((c: any) => c.body);
-    expect(bodies).toEqual(['c1', 'c2']);
+    await expect(
+      executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+      ),
+    ).rejects.toThrow(/Sort field 'author\.name' is not supported/i);
   });
 
-  test('dotted sort emits trace with strategy reflecting aggregate path', async () => {
+  test('rejects dotted sort before fetch trace is emitted', async () => {
     const rows = makePosts(postIds);
     const trace = new TestTrace();
     const desc: MongoBatchFetchDescriptor = {
@@ -339,21 +326,22 @@ describe('Mongo dotted sort on o2m (aggregate path)', () => {
       userSort: 'author.name',
       userLimit: 2,
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-      trace,
-    );
-    const entry = trace.entries.find((e) => e.stage.includes('comments'));
-    expect(entry).toBeDefined();
-    expect(entry!.meta?.strategy).toBe('per-parent-c16');
-    expect(entry!.meta?.userSort).toBe(true);
+    await expect(
+      executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+        trace,
+      ),
+    ).rejects.toThrow(/Sort field 'author\.name' is not supported/i);
+    expect(
+      trace.entries.find((e) => e.stage.includes('comments')),
+    ).toBeUndefined();
   });
 
   test('simple sort without dots stays on find() path (no aggregate)', async () => {

--- a/test/query-builder/deep-validation.spec.ts
+++ b/test/query-builder/deep-validation.spec.ts
@@ -235,17 +235,17 @@ describe('validateDeepOptions', () => {
         { comments: { sort: 'nonexistentColumn' } },
         metadata,
       ),
-    ).toThrow(/references unknown field 'nonexistentColumn'/);
+    ).toThrow(/does not exist/i);
   });
 
-  test('accepts valid dotted sort through m2o chain', () => {
+  test('rejects dotted sort through m2o chain', () => {
     expect(() =>
       validateDeepOptions(
         'posts',
         { author: { sort: 'company.name' } },
         metadata,
       ),
-    ).not.toThrow();
+    ).toThrow(/Sort field 'company\.name' is not supported/i);
   });
 
   test('rejects dotted sort through o2m relation', () => {
@@ -255,7 +255,7 @@ describe('validateDeepOptions', () => {
         { posts: { sort: 'comments.body', limit: 3 } },
         metadata,
       ),
-    ).toThrow(/one-to-many.*sort path must only traverse/i);
+    ).toThrow(/Sort field 'comments\.body' is not supported/i);
   });
 
   test('validates nested deep recursively', () => {
@@ -311,24 +311,24 @@ describe('validateDeepOptions', () => {
     ).not.toThrow();
   });
 
-  test('accepts dotted sort at max 3 hops (author.company.region.name)', () => {
+  test('rejects dotted sort at any depth', () => {
     expect(() =>
       validateDeepOptions(
         'posts',
         { comments: { sort: 'post.author.company.name' } },
         metadata,
       ),
-    ).not.toThrow();
+    ).toThrow(/Sort field 'post\.author\.company\.name' is not supported/i);
   });
 
-  test('rejects dotted sort exceeding 3 hops', () => {
+  test('rejects dotted sort before hop-depth validation', () => {
     expect(() =>
       validateDeepOptions(
         'posts',
         { comments: { sort: 'post.author.company.region.name' } },
         metadata,
       ),
-    ).toThrow(/exceeds max dotted hops of 3/i);
+    ).toThrow(/Sort field 'post\.author\.company\.region\.name' is not supported/i);
   });
 
   test('accepts nested filter at max 3 hops (post.author.company.name)', () => {

--- a/test/query-builder/relation-count-sort.spec.ts
+++ b/test/query-builder/relation-count-sort.spec.ts
@@ -1,0 +1,687 @@
+import knex, { Knex } from 'knex';
+import { MongoClient, Db, ObjectId } from 'mongodb';
+import {
+  MongoQueryExecutor,
+  QueryPlanner,
+  SqlQueryExecutor,
+  validateDeepOptions,
+} from '@enfyra/kernel';
+
+const MONGO_URI =
+  process.env.MONGO_TEST_URI ||
+  'mongodb://enfyra_admin:enfyra_password_123@localhost:27017/?authSource=admin';
+const DB_NAME = `test_relation_count_sort_${Date.now()}`;
+
+const REAL_SQL_DBS = [
+  {
+    name: 'postgres',
+    client: 'pg',
+    connection:
+      process.env.PG_TEST_URI ||
+      'postgresql://root:1234@localhost:5432/postgres',
+    dbType: 'postgres' as const,
+  },
+  {
+    name: 'mysql',
+    client: 'mysql2',
+    connection:
+      process.env.MYSQL_TEST_URI || 'mysql://root:1234@localhost:3306/mysql',
+    dbType: 'mysql' as const,
+  },
+];
+
+function makeMetadata(isMongo = false) {
+  const idColumn = isMongo
+    ? { name: '_id', type: 'objectid', isPrimary: true }
+    : { name: 'id', type: 'integer', isPrimary: true };
+  return {
+    tables: new Map<string, any>([
+      [
+        'posts',
+        {
+          name: 'posts',
+          columns: [
+            idColumn,
+            { name: 'title', type: 'varchar' },
+            { name: 'authorId', type: isMongo ? 'objectid' : 'integer' },
+          ],
+          relations: [
+            {
+              propertyName: 'comments',
+              type: 'one-to-many',
+              targetTableName: 'comments',
+              targetTable: 'comments',
+              foreignKeyColumn: 'postId',
+              mappedBy: 'postId',
+              isInverse: true,
+            },
+            {
+              propertyName: 'tags',
+              type: 'many-to-many',
+              targetTableName: 'tags',
+              targetTable: 'tags',
+              junctionTableName: 'posts_tags',
+              junctionSourceColumn: 'postId',
+              junctionTargetColumn: 'tagId',
+              isInverse: false,
+            },
+            {
+              propertyName: 'author',
+              type: 'many-to-one',
+              targetTableName: 'users',
+              targetTable: 'users',
+              foreignKeyColumn: 'authorId',
+              isInverse: false,
+            },
+          ],
+        },
+      ],
+      [
+        'comments',
+        {
+          name: 'comments',
+          columns: [
+            idColumn,
+            { name: 'body', type: 'varchar' },
+            { name: 'postId', type: isMongo ? 'objectid' : 'integer' },
+          ],
+          relations: [],
+        },
+      ],
+      [
+        'tags',
+        {
+          name: 'tags',
+          columns: [idColumn, { name: 'label', type: 'varchar' }],
+          relations: [
+            {
+              propertyName: 'posts',
+              type: 'many-to-many',
+              targetTableName: 'posts',
+              targetTable: 'posts',
+              mappedBy: 'tags',
+              isInverse: true,
+            },
+          ],
+        },
+      ],
+      [
+        'users',
+        {
+          name: 'users',
+          columns: [idColumn, { name: 'name', type: 'varchar' }],
+          relations: [],
+        },
+      ],
+      [
+        'categories',
+        {
+          name: 'categories',
+          columns: [
+            { name: 'code', type: 'varchar', isPrimary: true },
+            { name: 'name', type: 'varchar' },
+          ],
+          relations: [
+            {
+              propertyName: 'items',
+              type: 'one-to-many',
+              targetTableName: 'items',
+              targetTable: 'items',
+              foreignKeyColumn: 'categoryCode',
+              mappedBy: 'categoryCode',
+              isInverse: true,
+            },
+          ],
+        },
+      ],
+      [
+        'items',
+        {
+          name: 'items',
+          columns: [
+            idColumn,
+            { name: 'categoryCode', type: 'varchar' },
+            { name: 'label', type: 'varchar' },
+          ],
+          relations: [],
+        },
+      ],
+    ]),
+  };
+}
+
+describe('relation _count() sort (SQL)', () => {
+  let db: Knex;
+  let executor: SqlQueryExecutor;
+  const metadata = makeMetadata();
+
+  beforeAll(async () => {
+    db = knex({
+      client: 'sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+
+    await db.schema.createTable('users', (t) => {
+      t.increments('id').primary();
+      t.string('name');
+    });
+    await db.schema.createTable('posts', (t) => {
+      t.increments('id').primary();
+      t.string('title');
+      t.integer('authorId');
+    });
+    await db.schema.createTable('comments', (t) => {
+      t.increments('id').primary();
+      t.string('body');
+      t.integer('postId');
+    });
+    await db.schema.createTable('tags', (t) => {
+      t.increments('id').primary();
+      t.string('label');
+    });
+    await db.schema.createTable('posts_tags', (t) => {
+      t.integer('postId');
+      t.integer('tagId');
+    });
+    await db.schema.createTable('posts_tags_tags', (t) => {
+      t.integer('postsId');
+      t.integer('tagsId');
+    });
+    await db.schema.createTable('categories', (t) => {
+      t.string('code').primary();
+      t.string('name');
+    });
+    await db.schema.createTable('items', (t) => {
+      t.increments('id').primary();
+      t.string('categoryCode');
+      t.string('label');
+    });
+
+    await db('users').insert([{ id: 1, name: 'Alice' }]);
+    await db('posts').insert([
+      { id: 1, title: 'Post A', authorId: 1 },
+      { id: 2, title: 'Post B', authorId: 1 },
+      { id: 3, title: 'Post C', authorId: 1 },
+    ]);
+    await db('comments').insert([
+      { id: 1, body: 'a1', postId: 1 },
+      { id: 2, body: 'a2', postId: 1 },
+      { id: 3, body: 'a3', postId: 1 },
+      { id: 4, body: 'b1', postId: 2 },
+    ]);
+    await db('tags').insert([
+      { id: 1, label: 'one' },
+      { id: 2, label: 'two' },
+      { id: 3, label: 'three' },
+    ]);
+    await db('posts_tags').insert([
+      { postId: 1, tagId: 1 },
+      { postId: 2, tagId: 1 },
+      { postId: 2, tagId: 2 },
+      { postId: 2, tagId: 3 },
+      { postId: 3, tagId: 1 },
+    ]);
+    await db('posts_tags_tags').insert([
+      { postsId: 1, tagsId: 1 },
+      { postsId: 2, tagsId: 1 },
+      { postsId: 2, tagsId: 2 },
+      { postsId: 2, tagsId: 3 },
+      { postsId: 3, tagsId: 1 },
+    ]);
+    await db('categories').insert([
+      { code: 'alpha', name: 'Alpha' },
+      { code: 'beta', name: 'Beta' },
+      { code: 'gamma', name: 'Gamma' },
+    ]);
+    await db('items').insert([
+      { id: 1, categoryCode: 'beta', label: 'b1' },
+      { id: 2, categoryCode: 'beta', label: 'b2' },
+      { id: 3, categoryCode: 'alpha', label: 'a1' },
+    ]);
+
+    executor = new SqlQueryExecutor(db, 'sqlite');
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  test('sorts root rows by o2m count', async () => {
+    const result = await executor.execute({
+      tableName: 'posts',
+      fields: ['id', 'title'],
+      sort: ['-_count(comments)', 'id'],
+      limit: 3,
+      metadata,
+    });
+
+    expect(result.data.map((row: any) => row.id)).toEqual([1, 2, 3]);
+  });
+
+  test('sorts root rows by m2m count', async () => {
+    const result = await executor.execute({
+      tableName: 'posts',
+      fields: ['id', 'title'],
+      sort: ['-_count(tags)', 'id'],
+      limit: 3,
+      metadata,
+    });
+
+    expect(result.data.map((row: any) => row.id)).toEqual([2, 1, 3]);
+  });
+
+  test('sorts root rows by inverse m2m count with generated mappedBy columns', async () => {
+    const result = await executor.execute({
+      tableName: 'tags',
+      fields: ['id', 'label'],
+      sort: ['-_count(posts)', 'id'],
+      limit: 0,
+      metadata,
+    });
+
+    expect(result.data.map((row: any) => row.id)).toEqual([1, 2, 3]);
+  });
+
+  test('keeps local sort priority before _count sort', async () => {
+    const result = await executor.execute({
+      tableName: 'posts',
+      fields: ['id', 'title'],
+      sort: ['title', '-_count(comments)'],
+      limit: 0,
+      metadata,
+    });
+
+    expect(result.data.map((row: any) => row.id)).toEqual([1, 2, 3]);
+  });
+
+  test('sorts by o2m count with a non-id primary key', async () => {
+    const result = await executor.execute({
+      tableName: 'categories',
+      fields: ['code', 'name'],
+      sort: ['-_count(items)', 'code'],
+      limit: 0,
+      metadata,
+    });
+
+    expect(result.data.map((row: any) => row.code)).toEqual([
+      'beta',
+      'alpha',
+      'gamma',
+    ]);
+  });
+
+  test('rejects _count on scalar relations', () => {
+    expect(() =>
+      new QueryPlanner().plan({
+        tableName: 'posts',
+        sort: '_count(author)',
+        metadata,
+        dbType: 'sqlite',
+      }),
+    ).toThrow(/only supported for list relations/i);
+  });
+
+  test.each([
+    ['_count', /Use _count\(relationName\)/i],
+    ['_count()', /Use _count\(relationName\)/i],
+    ['_count(comments.body)', /direct relation name/i],
+    ['_count(unknown)', /does not exist/i],
+  ])('rejects invalid sort function %s', (sort, error) => {
+    expect(() =>
+      new QueryPlanner().plan({
+        tableName: 'posts',
+        sort,
+        metadata,
+        dbType: 'sqlite',
+      }),
+    ).toThrow(error);
+  });
+
+  test('does not allow _count inside deep relation sort', () => {
+    expect(() =>
+      validateDeepOptions(
+        'posts',
+        { comments: { sort: '_count(replies)' } },
+        metadata,
+      ),
+    ).toThrow(/does not exist|not supported/i);
+  });
+});
+
+describe('relation _count() sort (Mongo)', () => {
+  let client: MongoClient;
+  let db: Db;
+  let executor: MongoQueryExecutor;
+  let available = true;
+  const metadata = makeMetadata(true);
+  const postIds = [new ObjectId(), new ObjectId(), new ObjectId()];
+  const tagIds = [new ObjectId(), new ObjectId(), new ObjectId()];
+
+  beforeAll(async () => {
+    try {
+      client = await MongoClient.connect(MONGO_URI, {
+        serverSelectionTimeoutMS: 2000,
+      });
+    } catch {
+      available = false;
+      return;
+    }
+
+    db = client.db(DB_NAME);
+    await db.collection('posts').insertMany([
+      { _id: postIds[0], title: 'Post A' },
+      { _id: postIds[1], title: 'Post B' },
+      { _id: postIds[2], title: 'Post C' },
+    ]);
+    await db.collection('comments').insertMany([
+      { _id: new ObjectId(), body: 'a1', postId: postIds[0] },
+      { _id: new ObjectId(), body: 'a2', postId: postIds[0] },
+      { _id: new ObjectId(), body: 'a3', postId: postIds[0] },
+      { _id: new ObjectId(), body: 'b1', postId: postIds[1] },
+    ]);
+    await db.collection('tags').insertMany([
+      { _id: tagIds[0], label: 'one' },
+      { _id: tagIds[1], label: 'two' },
+      { _id: tagIds[2], label: 'three' },
+    ]);
+    await db.collection('posts_tags').insertMany([
+      { postId: postIds[0], tagId: tagIds[0] },
+      { postId: postIds[1], tagId: tagIds[0] },
+      { postId: postIds[1], tagId: tagIds[1] },
+      { postId: postIds[1], tagId: tagIds[2] },
+      { postId: postIds[2], tagId: tagIds[0] },
+    ]);
+    await db.collection('posts_tags_tags').insertMany([
+      { postsId: postIds[0], tagsId: tagIds[0] },
+      { postsId: postIds[1], tagsId: tagIds[0] },
+      { postsId: postIds[1], tagsId: tagIds[1] },
+      { postsId: postIds[1], tagsId: tagIds[2] },
+      { postsId: postIds[2], tagsId: tagIds[0] },
+    ]);
+    await db.collection('categories').insertMany([
+      { _id: new ObjectId(), code: 'alpha', name: 'Alpha' },
+      { _id: new ObjectId(), code: 'beta', name: 'Beta' },
+      { _id: new ObjectId(), code: 'gamma', name: 'Gamma' },
+    ]);
+    await db.collection('items').insertMany([
+      { _id: new ObjectId(), categoryCode: 'beta', label: 'b1' },
+      { _id: new ObjectId(), categoryCode: 'beta', label: 'b2' },
+      { _id: new ObjectId(), categoryCode: 'alpha', label: 'a1' },
+    ]);
+
+    executor = new MongoQueryExecutor({
+      getDb: () => db,
+      collection: (name: string) => db.collection(name),
+    } as any);
+  });
+
+  afterAll(async () => {
+    if (!available) return;
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  function runOrSkip(name: string, fn: () => Promise<void>) {
+    test(name, async () => {
+      if (!available) return;
+      await fn();
+    });
+  }
+
+  async function run(sort: string | string[]) {
+    const base = {
+      tableName: 'posts',
+      fields: ['_id', 'title'],
+      sort,
+      limit: 3,
+      metadata,
+      dbType: 'mongodb' as any,
+    };
+    const plan = new QueryPlanner().plan(base);
+    return executor.execute({ ...base, plan });
+  }
+
+  runOrSkip('sorts root rows by o2m count', async () => {
+    const result = await run(['-_count(comments)', '_id']);
+    expect(result.data.map((row: any) => row._id)).toEqual([
+      String(postIds[0]),
+      String(postIds[1]),
+      String(postIds[2]),
+    ]);
+  });
+
+  runOrSkip('sorts root rows by m2m count', async () => {
+    const result = await run(['-_count(tags)', '_id']);
+    expect(result.data.map((row: any) => row._id)).toEqual([
+      String(postIds[1]),
+      String(postIds[0]),
+      String(postIds[2]),
+    ]);
+  });
+
+  runOrSkip('sorts root rows by inverse m2m count with generated mappedBy columns', async () => {
+    const base = {
+      tableName: 'tags',
+      fields: ['_id', 'label'],
+      sort: ['-_count(posts)', '_id'],
+      limit: 0,
+      metadata,
+      dbType: 'mongodb' as any,
+    };
+    const plan = new QueryPlanner().plan(base);
+    const result = await executor.execute({ ...base, plan });
+
+    expect(result.data.map((row: any) => row._id)).toEqual([
+      String(tagIds[0]),
+      String(tagIds[1]),
+      String(tagIds[2]),
+    ]);
+  });
+
+  runOrSkip('does not expose temporary count fields', async () => {
+    const result = await run(['-_count(comments)', '_id']);
+    expect(
+      Object.keys(result.data[0]).some((key) =>
+        key.startsWith('__sort_count_'),
+      ),
+    ).toBe(false);
+  });
+
+  runOrSkip('sorts by o2m count with a non-_id primary key', async () => {
+    const base = {
+      tableName: 'categories',
+      fields: ['code', 'name'],
+      sort: ['-_count(items)', 'code'],
+      limit: 0,
+      metadata,
+      dbType: 'mongodb' as any,
+    };
+    const plan = new QueryPlanner().plan(base);
+    const result = await executor.execute({ ...base, plan });
+
+    expect(result.data.map((row: any) => row.code)).toEqual([
+      'beta',
+      'alpha',
+      'gamma',
+    ]);
+  });
+});
+
+for (const cfg of REAL_SQL_DBS) {
+  describe(`relation _count() sort (${cfg.name} real DB)`, () => {
+    let db: Knex;
+    let available = true;
+    const prefix = `__rcs_${cfg.name}_${Date.now()}_`;
+    const tables = {
+      posts: `${prefix}posts`,
+      comments: `${prefix}comments`,
+      tags: `${prefix}tags`,
+      junction: `${prefix}posts_tags`,
+    };
+    const metadata = {
+      tables: new Map<string, any>([
+        [
+          tables.posts,
+          {
+            name: tables.posts,
+            columns: [
+              { name: 'id', type: 'integer', isPrimary: true },
+              { name: 'title', type: 'varchar' },
+            ],
+            relations: [
+              {
+                propertyName: 'comments',
+                type: 'one-to-many',
+                targetTableName: tables.comments,
+                targetTable: tables.comments,
+                foreignKeyColumn: 'postId',
+                mappedBy: 'postId',
+                isInverse: true,
+              },
+              {
+                propertyName: 'tags',
+                type: 'many-to-many',
+                targetTableName: tables.tags,
+                targetTable: tables.tags,
+                junctionTableName: tables.junction,
+                junctionSourceColumn: 'postId',
+                junctionTargetColumn: 'tagId',
+                isInverse: false,
+              },
+            ],
+          },
+        ],
+        [
+          tables.comments,
+          {
+            name: tables.comments,
+            columns: [
+              { name: 'id', type: 'integer', isPrimary: true },
+              { name: 'postId', type: 'integer' },
+            ],
+            relations: [],
+          },
+        ],
+        [
+          tables.tags,
+          {
+            name: tables.tags,
+            columns: [
+              { name: 'id', type: 'integer', isPrimary: true },
+              { name: 'label', type: 'varchar' },
+            ],
+            relations: [],
+          },
+        ],
+      ]),
+    };
+
+    beforeAll(async () => {
+      db = knex({
+        client: cfg.client,
+        connection: cfg.connection,
+        pool: { min: 0, max: 4 },
+      });
+
+      try {
+        await db.raw('SELECT 1');
+      } catch {
+        available = false;
+        return;
+      }
+
+      await db.schema.dropTableIfExists(tables.junction);
+      await db.schema.dropTableIfExists(tables.comments);
+      await db.schema.dropTableIfExists(tables.posts);
+      await db.schema.dropTableIfExists(tables.tags);
+
+      await db.schema.createTable(tables.posts, (t) => {
+        t.integer('id').primary();
+        t.string('title');
+      });
+      await db.schema.createTable(tables.comments, (t) => {
+        t.integer('id').primary();
+        t.integer('postId');
+      });
+      await db.schema.createTable(tables.tags, (t) => {
+        t.integer('id').primary();
+        t.string('label');
+      });
+      await db.schema.createTable(tables.junction, (t) => {
+        t.integer('postId');
+        t.integer('tagId');
+      });
+
+      await db(tables.posts).insert([
+        { id: 1, title: 'A' },
+        { id: 2, title: 'B' },
+        { id: 3, title: 'C' },
+      ]);
+      await db(tables.comments).insert([
+        { id: 1, postId: 1 },
+        { id: 2, postId: 1 },
+        { id: 3, postId: 1 },
+        { id: 4, postId: 2 },
+      ]);
+      await db(tables.tags).insert([
+        { id: 1, label: 'one' },
+        { id: 2, label: 'two' },
+        { id: 3, label: 'three' },
+      ]);
+      await db(tables.junction).insert([
+        { postId: 1, tagId: 1 },
+        { postId: 2, tagId: 1 },
+        { postId: 2, tagId: 2 },
+        { postId: 2, tagId: 3 },
+        { postId: 3, tagId: 1 },
+      ]);
+    }, 30000);
+
+    afterAll(async () => {
+      if (!db) return;
+      try {
+        if (available) {
+          await db.schema.dropTableIfExists(tables.junction);
+          await db.schema.dropTableIfExists(tables.comments);
+          await db.schema.dropTableIfExists(tables.posts);
+          await db.schema.dropTableIfExists(tables.tags);
+        }
+      } finally {
+        await db.destroy();
+      }
+    }, 30000);
+
+    function runOrSkip(name: string, fn: () => Promise<void>) {
+      test(name, async () => {
+        if (!available) return;
+        await fn();
+      });
+    }
+
+    runOrSkip('executes _count() ordering with dialect quoting', async () => {
+      const executor = new SqlQueryExecutor(db, cfg.dbType);
+      const byComments = await executor.execute({
+        tableName: tables.posts,
+        fields: ['id', 'title'],
+        sort: ['-_count(comments)', 'id'],
+        limit: 0,
+        metadata,
+      });
+      const byTags = await executor.execute({
+        tableName: tables.posts,
+        fields: ['id', 'title'],
+        sort: ['-_count(tags)', 'id'],
+        limit: 0,
+        metadata,
+      });
+
+      expect(byComments.data.map((row: any) => Number(row.id))).toEqual([
+        1, 2, 3,
+      ]);
+      expect(byTags.data.map((row: any) => Number(row.id))).toEqual([
+        2, 1, 3,
+      ]);
+    }, 30000);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,10 +600,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@enfyra/kernel@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@enfyra/kernel/-/kernel-1.0.9.tgz#588709d664a00a4df1848ec8de287d30cd2ca7c0"
-  integrity sha512-pC8/F5ZZUZdO+UDp0oUF2UUfcXVveWguSKfxpTwAPtklUMNnSS7tktJHUax/5398Lo284B+uBINEp6vFThGkYQ==
+"@enfyra/kernel@1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@enfyra/kernel/-/kernel-1.0.10.tgz#7dd3558084e07e6c461ff973b03d124169d81fc1"
+  integrity sha512-8WUb55vj1YY+oaRonYFtcm10ew12pLQzxd7UnlEPSwDThuG9c9vDs6TNXFPeSqJbGoH29Qe53IjONzOufwESPg==
   dependencies:
     "@types/node" "^24.12.2"
     isolated-vm "^6.1.2"


### PR DESCRIPTION
- Bump version of @enfyra/kernel from 1.0.9 to 1.0.10
- Update package version from 2.1.7-patch-1 to 2.1.7-patch-2

test: add comprehensive tests for script code utilities

- Introduce tests for normalizeScriptPatch and normalizeFlowStepScriptConfig functions
- Validate behavior for legacy code patches, recompilation, and JSON flow configs

test: enhance relation count sort tests for SQL and Mongo

- Implement tests for sorting by relation counts in SQL and Mongo
- Validate behavior for invalid sort functions and deep relation sorting

test: add kernel batch utilities adversarial behavior tests

- Introduce tests for chunkedFetch and perParentRun functions
- Validate concurrency limits and error propagation

test: create relation count sort tests for real SQL databases

- Add tests for sorting by relation counts in PostgreSQL and MySQL
- Validate behavior for various sorting scenarios and edge cases