### PR TITLE
feat: enhance session cleanup and caching mechanisms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.2.7-patch.2",
+  "version": "2.2.8",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/container.ts
+++ b/src/container.ts
@@ -129,6 +129,7 @@ import {
   RedisRuntimeCacheStore,
   RepoRegistryService,
   RouteCacheService,
+  RuntimeNamespaceLifecycleService,
   RuntimeRegistryService,
   RuntimeReloadAuditService,
   RuntimeScriptRepairService,
@@ -303,6 +304,7 @@ export interface Cradle {
   cacheService: CacheService;
   userCacheService: UserCacheService;
   redisPubSubService: RedisPubSubService;
+  runtimeNamespaceLifecycleService: RuntimeNamespaceLifecycleService;
   redisRuntimeCacheStore: RedisRuntimeCacheStore;
   metadataCacheService: MetadataCacheService;
   routeCacheService: RouteCacheService;
@@ -577,6 +579,9 @@ export function buildContainer(): AwilixContainer<Cradle> {
     cacheService: asClass(CacheService).singleton(),
     userCacheService: asClass(UserCacheService).singleton(),
     redisPubSubService: asClass(RedisPubSubService)
+      .singleton()
+      .disposer((service) => service.onDestroy()),
+    runtimeNamespaceLifecycleService: asClass(RuntimeNamespaceLifecycleService)
       .singleton()
       .disposer((service) => service.onDestroy()),
     redisRuntimeCacheStore: asClass(RedisRuntimeCacheStore).singleton(),

--- a/src/domain/auth/services/oauth-exchange-code.service.ts
+++ b/src/domain/auth/services/oauth-exchange-code.service.ts
@@ -61,11 +61,10 @@ export class OAuthExchangeCodeService {
       pending,
       CODE_TTL_MS * 2,
     );
-    await this.redis
-      .pipeline()
-      .zadd(this.pendingIndexKey(), expiresAt, code)
-      .pexpire(this.pendingIndexKey(), CODE_TTL_MS * 2)
-      .exec();
+    const pipeline = this.redisTransaction();
+    pipeline.zadd(this.pendingIndexKey(), expiresAt, code);
+    pipeline.pexpire(this.pendingIndexKey(), CODE_TTL_MS * 2);
+    await pipeline.exec();
 
     return code;
   }
@@ -155,5 +154,14 @@ export class OAuthExchangeCodeService {
     return this.nodeName
       ? `${this.nodeName}:${PENDING_INDEX_KEY}`
       : PENDING_INDEX_KEY;
+  }
+
+  private redisTransaction(): ReturnType<Redis['pipeline']> {
+    const redis = this.redis as Redis & {
+      multi?: () => ReturnType<Redis['pipeline']>;
+    };
+    return typeof redis.multi === 'function'
+      ? redis.multi()
+      : this.redis.pipeline();
   }
 }

--- a/src/domain/auth/services/oauth-exchange-code.service.ts
+++ b/src/domain/auth/services/oauth-exchange-code.service.ts
@@ -56,8 +56,16 @@ export class OAuthExchangeCodeService {
     };
 
     await this.cacheService.set(this.codeKey(code), payload, CODE_TTL_MS);
-    await this.cacheService.set(this.pendingKey(code), pending, 0);
-    await this.redis.zadd(this.pendingIndexKey(), expiresAt, code);
+    await this.cacheService.set(
+      this.pendingKey(code),
+      pending,
+      CODE_TTL_MS * 2,
+    );
+    await this.redis
+      .pipeline()
+      .zadd(this.pendingIndexKey(), expiresAt, code)
+      .pexpire(this.pendingIndexKey(), CODE_TTL_MS * 2)
+      .exec();
 
     return code;
   }
@@ -71,7 +79,9 @@ export class OAuthExchangeCodeService {
       this.codeKey(code),
     );
     if (!payload) {
-      throw new BadRequestException('OAuth exchange code is invalid or expired');
+      throw new BadRequestException(
+        'OAuth exchange code is invalid or expired',
+      );
     }
 
     await this.deleteCode(code);
@@ -111,6 +121,13 @@ export class OAuthExchangeCodeService {
       }
     }
 
+    const remaining = await this.redis.zcard(indexKey);
+    if (remaining > 0) {
+      await this.redis.pexpire(indexKey, CODE_TTL_MS * 2);
+    } else {
+      await this.redis.del(indexKey);
+    }
+
     return { deleted };
   }
 
@@ -135,6 +152,8 @@ export class OAuthExchangeCodeService {
   }
 
   private pendingIndexKey(): string {
-    return this.nodeName ? `${this.nodeName}:${PENDING_INDEX_KEY}` : PENDING_INDEX_KEY;
+    return this.nodeName
+      ? `${this.nodeName}:${PENDING_INDEX_KEY}`
+      : PENDING_INDEX_KEY;
   }
 }

--- a/src/domain/auth/services/session-cleanup.service.ts
+++ b/src/domain/auth/services/session-cleanup.service.ts
@@ -44,7 +44,13 @@ export class SessionCleanupService {
     await this.cleanupQueue.upsertJobScheduler(
       'session-cleanup-daily',
       { pattern: '0 2 * * *' },
-      { name: 'cleanup-expired-sessions' },
+      {
+        name: 'cleanup-expired-sessions',
+        opts: {
+          removeOnComplete: { count: 30, age: 3600 * 24 * 7 },
+          removeOnFail: { count: 30, age: 3600 * 24 * 30 },
+        },
+      },
     );
   }
 

--- a/src/domain/auth/services/session-cleanup.service.ts
+++ b/src/domain/auth/services/session-cleanup.service.ts
@@ -4,6 +4,7 @@ import { SYSTEM_QUEUES } from '../../../shared/utils/constant';
 import { EnvService } from '../../../shared/services';
 import { Logger } from '../../../shared/logger';
 import { getErrorMessage } from '../../../shared/utils/error.util';
+import type { RuntimeNamespaceLifecycleService } from '../../../engines/cache/services/runtime-namespace-lifecycle.service';
 
 const BATCH_SIZE = 20;
 
@@ -12,16 +13,20 @@ export class SessionCleanupService {
   private readonly queryBuilderService: IQueryBuilder;
   private readonly cleanupQueue: Queue;
   private readonly envService: EnvService;
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
   private worker?: Worker;
 
   constructor(deps: {
     queryBuilderService: IQueryBuilder;
     cleanupQueue: Queue;
     envService: EnvService;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
   }) {
     this.queryBuilderService = deps.queryBuilderService;
     this.cleanupQueue = deps.cleanupQueue;
     this.envService = deps.envService;
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
   }
 
   async init() {
@@ -51,6 +56,9 @@ export class SessionCleanupService {
           removeOnFail: { count: 30, age: 3600 * 24 * 30 },
         },
       },
+    );
+    await this.runtimeNamespaceLifecycleService?.renewSystemQueueKeys(
+      SYSTEM_QUEUES.SESSION_CLEANUP,
     );
   }
 

--- a/src/engines/cache/services/cache.service.ts
+++ b/src/engines/cache/services/cache.service.ts
@@ -87,18 +87,12 @@ export class CacheService implements ICache {
     if (ttlMs > 0) {
       await this.redis.set(decoratedKey, serializedValue, 'PX', ttlMs);
     } else {
-      const namespaceTtlMs =
-        this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
-      if (namespaceTtlMs && namespaceTtlMs > 0) {
-        await this.redis.set(
-          decoratedKey,
-          serializedValue,
-          'PX',
-          namespaceTtlMs,
-        );
-      } else {
-        await this.redis.set(decoratedKey, serializedValue);
-      }
+      await this.redis.set(
+        decoratedKey,
+        serializedValue,
+        'PX',
+        this.lifecycleTtlMs(),
+      );
     }
   }
   async exists(key: string, value: any): Promise<boolean> {
@@ -115,12 +109,20 @@ export class CacheService implements ICache {
   }
   async setNoExpire<T = any>(key: string, val: T): Promise<void> {
     const decoratedKey = this.decorateKey(key);
+    await this.redis.set(
+      decoratedKey,
+      JSON.stringify(val),
+      'PX',
+      this.lifecycleTtlMs(),
+    );
+  }
+
+  private lifecycleTtlMs(): number {
     const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
-    if (ttlMs && ttlMs > 0) {
-      await this.redis.set(decoratedKey, JSON.stringify(val), 'PX', ttlMs);
-    } else {
-      await this.redis.set(decoratedKey, JSON.stringify(val));
+    if (!ttlMs || ttlMs <= 0) {
+      throw new Error('Runtime namespace lifecycle TTL is required');
     }
+    return ttlMs;
   }
   async clearAll(): Promise<void> {
     if (!this.nodeName) {

--- a/src/engines/cache/services/cache.service.ts
+++ b/src/engines/cache/services/cache.service.ts
@@ -87,7 +87,18 @@ export class CacheService implements ICache {
     if (ttlMs > 0) {
       await this.redis.set(decoratedKey, serializedValue, 'PX', ttlMs);
     } else {
-      await this.redis.set(decoratedKey, serializedValue);
+      const namespaceTtlMs =
+        this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
+      if (namespaceTtlMs && namespaceTtlMs > 0) {
+        await this.redis.set(
+          decoratedKey,
+          serializedValue,
+          'PX',
+          namespaceTtlMs,
+        );
+      } else {
+        await this.redis.set(decoratedKey, serializedValue);
+      }
     }
   }
   async exists(key: string, value: any): Promise<boolean> {

--- a/src/engines/cache/services/cache.service.ts
+++ b/src/engines/cache/services/cache.service.ts
@@ -1,14 +1,22 @@
 import { Redis } from 'ioredis';
 import { EnvService } from '../../../shared/services';
 import { ICache } from '../../../domain/shared/interfaces/cache.interface';
+import { RuntimeNamespaceLifecycleService } from './runtime-namespace-lifecycle.service';
 
 export class CacheService implements ICache {
   private readonly redis: Redis;
   private readonly nodeName: string | null;
   private readonly envService: EnvService;
-  constructor(deps: { redis: Redis; envService: EnvService }) {
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
+  constructor(deps: {
+    redis: Redis;
+    envService: EnvService;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
+  }) {
     this.redis = deps.redis;
     this.envService = deps.envService;
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
     if (!this.redis) {
       throw new Error(
         'Redis connection not available - CacheService cannot initialize',
@@ -96,7 +104,12 @@ export class CacheService implements ICache {
   }
   async setNoExpire<T = any>(key: string, val: T): Promise<void> {
     const decoratedKey = this.decorateKey(key);
-    await this.redis.set(decoratedKey, JSON.stringify(val));
+    const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
+    if (ttlMs && ttlMs > 0) {
+      await this.redis.set(decoratedKey, JSON.stringify(val), 'PX', ttlMs);
+    } else {
+      await this.redis.set(decoratedKey, JSON.stringify(val));
+    }
   }
   async clearAll(): Promise<void> {
     if (!this.nodeName) {

--- a/src/engines/cache/services/cache.service.ts
+++ b/src/engines/cache/services/cache.service.ts
@@ -49,7 +49,7 @@ export class CacheService implements ICache {
       decoratedKey,
       serializedValue,
       'PX',
-      ttlMs,
+      ttlMs > 0 ? ttlMs : this.lifecycleTtlMs(),
       'NX',
     );
     return result === 'OK';

--- a/src/engines/cache/services/guard-evaluator.service.ts
+++ b/src/engines/cache/services/guard-evaluator.service.ts
@@ -92,19 +92,19 @@ export class GuardEvaluatorService {
     switch (rule.type) {
       case 'rate_limit_by_ip':
         return this.evalRateLimit(
-          `ip:${evalCtx.clientIp}:${evalCtx.routePath}`,
+          `guard_rule:${rule.id}:ip:${evalCtx.clientIp}`,
           rule,
           guardName,
         );
       case 'rate_limit_by_user':
         return this.evalRateLimit(
-          `user:${evalCtx.userId || 'anonymous'}:${evalCtx.routePath}`,
+          `guard_rule:${rule.id}:user:${evalCtx.userId || 'anonymous'}`,
           rule,
           guardName,
         );
       case 'rate_limit_by_route':
         return this.evalRateLimit(
-          `route:${evalCtx.routePath}`,
+          `guard_rule:${rule.id}:route:${evalCtx.routePath}`,
           rule,
           guardName,
         );

--- a/src/engines/cache/services/index.ts
+++ b/src/engines/cache/services/index.ts
@@ -20,6 +20,7 @@ export * from './repo-registry.service';
 export * from './route-cache.service';
 export * from './runtime-registry.service';
 export * from './runtime-reload-audit.service';
+export * from './runtime-namespace-lifecycle.service';
 export * from './runtime-script-repair.service';
 export * from './setting-cache.service';
 export * from './storage-config-cache-builder.service';

--- a/src/engines/cache/services/rate-limit.service.ts
+++ b/src/engines/cache/services/rate-limit.service.ts
@@ -37,6 +37,7 @@ export class RateLimitService {
       redis.call('PEXPIRE', key, window * 1000)
       return {1, limit - current - 1, now + window * 1000, 0}
     else
+      redis.call('PEXPIRE', key, window * 1000)
       local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
       local resetAt = tonumber(oldest[2]) + window * 1000
       return {0, 0, resetAt, math.ceil((resetAt - now) / 1000)}
@@ -149,6 +150,7 @@ export class RateLimitService {
       pipeline.zremrangebyscore(decoratedKey, 0, windowStart);
       pipeline.zcard(decoratedKey);
       pipeline.zrange(decoratedKey, 0, 0, 'WITHSCORES');
+      pipeline.pexpire(decoratedKey, options.perSeconds * 1000);
       const results = await pipeline.exec();
 
       if (!results) {

--- a/src/engines/cache/services/redis-runtime-cache-store.service.ts
+++ b/src/engines/cache/services/redis-runtime-cache-store.service.ts
@@ -152,7 +152,7 @@ export class RedisRuntimeCacheStore {
     const key = this.cacheKey(cacheIdentifier);
     const raw = await this.getBuffer(key);
     if (!raw) return null;
-    await this.runtimeNamespaceLifecycleService?.touchKey(key);
+    await this.touchLifecycleKey(key);
     return this.decode<RedisRuntimeCacheSnapshot<T>>(raw);
   }
 
@@ -181,7 +181,7 @@ export class RedisRuntimeCacheStore {
     const redisKey = this.auxKey(cacheIdentifier, key);
     const raw = await this.getBuffer(redisKey);
     if (!raw) return null;
-    await this.runtimeNamespaceLifecycleService?.touchKey(redisKey);
+    await this.touchLifecycleKey(redisKey);
     return this.decode<T>(raw);
   }
 
@@ -285,5 +285,12 @@ export class RedisRuntimeCacheStore {
       throw new Error('Runtime namespace lifecycle TTL is required');
     }
     return ttlMs;
+  }
+
+  private async touchLifecycleKey(key: string): Promise<void> {
+    if (!this.runtimeNamespaceLifecycleService) {
+      throw new Error('Runtime namespace lifecycle TTL is required');
+    }
+    await this.runtimeNamespaceLifecycleService.touchKey(key);
   }
 }

--- a/src/engines/cache/services/redis-runtime-cache-store.service.ts
+++ b/src/engines/cache/services/redis-runtime-cache-store.service.ts
@@ -167,12 +167,12 @@ export class RedisRuntimeCacheStore {
       data,
     };
     const key = this.cacheKey(cacheIdentifier);
-    const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
-    if (ttlMs && ttlMs > 0) {
-      await this.redis.set(key, this.encode(snapshot), 'PX', ttlMs);
-    } else {
-      await this.redis.set(key, this.encode(snapshot));
-    }
+    await this.redis.set(
+      key,
+      this.encode(snapshot),
+      'PX',
+      this.lifecycleTtlMs(),
+    );
     return snapshot;
   }
 
@@ -192,12 +192,12 @@ export class RedisRuntimeCacheStore {
   ): Promise<void> {
     if (!this.enabled) return;
     const redisKey = this.auxKey(cacheIdentifier, key);
-    const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
-    if (ttlMs && ttlMs > 0) {
-      await this.redis.set(redisKey, this.encode(value), 'PX', ttlMs);
-    } else {
-      await this.redis.set(redisKey, this.encode(value));
-    }
+    await this.redis.set(
+      redisKey,
+      this.encode(value),
+      'PX',
+      this.lifecycleTtlMs(),
+    );
   }
 
   async deleteAuxByPrefix(
@@ -277,5 +277,13 @@ export class RedisRuntimeCacheStore {
       await new Promise((resolve) => setTimeout(resolve, 50));
     } while (Date.now() < deadline);
     return null;
+  }
+
+  private lifecycleTtlMs(): number {
+    const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
+    if (!ttlMs || ttlMs <= 0) {
+      throw new Error('Runtime namespace lifecycle TTL is required');
+    }
+    return ttlMs;
   }
 }

--- a/src/engines/cache/services/redis-runtime-cache-store.service.ts
+++ b/src/engines/cache/services/redis-runtime-cache-store.service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { serialize, deserialize } from 'node:v8';
 import type { Redis } from 'ioredis';
 import { EnvService } from '../../../shared/services';
+import { RuntimeNamespaceLifecycleService } from './runtime-namespace-lifecycle.service';
 
 export interface RedisRuntimeCacheSnapshot<T> {
   cacheIdentifier: string;
@@ -80,11 +81,18 @@ export class RedisRuntimeCacheStore {
   private readonly redis: Redis;
   private readonly nodeName: string;
   private readonly enabled: boolean;
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
 
-  constructor(deps: { redis: Redis; envService: EnvService }) {
+  constructor(deps: {
+    redis: Redis;
+    envService: EnvService;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
+  }) {
     this.redis = deps.redis;
     this.nodeName = deps.envService.get('NODE_NAME') || 'enfyra';
     this.enabled = deps.envService.get('REDIS_RUNTIME_CACHE') === true;
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
   }
 
   isEnabled(): boolean {
@@ -141,8 +149,10 @@ export class RedisRuntimeCacheStore {
     cacheIdentifier: string,
   ): Promise<RedisRuntimeCacheSnapshot<T> | null> {
     if (!this.enabled) return null;
-    const raw = await this.getBuffer(this.cacheKey(cacheIdentifier));
+    const key = this.cacheKey(cacheIdentifier);
+    const raw = await this.getBuffer(key);
     if (!raw) return null;
+    await this.runtimeNamespaceLifecycleService?.touchKey(key);
     return this.decode<RedisRuntimeCacheSnapshot<T>>(raw);
   }
 
@@ -156,14 +166,22 @@ export class RedisRuntimeCacheStore {
       updatedAt: new Date().toISOString(),
       data,
     };
-    await this.redis.set(this.cacheKey(cacheIdentifier), this.encode(snapshot));
+    const key = this.cacheKey(cacheIdentifier);
+    const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
+    if (ttlMs && ttlMs > 0) {
+      await this.redis.set(key, this.encode(snapshot), 'PX', ttlMs);
+    } else {
+      await this.redis.set(key, this.encode(snapshot));
+    }
     return snapshot;
   }
 
   async getAux<T>(cacheIdentifier: string, key: string): Promise<T | null> {
     if (!this.enabled) return null;
-    const raw = await this.getBuffer(this.auxKey(cacheIdentifier, key));
+    const redisKey = this.auxKey(cacheIdentifier, key);
+    const raw = await this.getBuffer(redisKey);
     if (!raw) return null;
+    await this.runtimeNamespaceLifecycleService?.touchKey(redisKey);
     return this.decode<T>(raw);
   }
 
@@ -173,10 +191,13 @@ export class RedisRuntimeCacheStore {
     value: T,
   ): Promise<void> {
     if (!this.enabled) return;
-    await this.redis.set(
-      this.auxKey(cacheIdentifier, key),
-      this.encode(value),
-    );
+    const redisKey = this.auxKey(cacheIdentifier, key);
+    const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
+    if (ttlMs && ttlMs > 0) {
+      await this.redis.set(redisKey, this.encode(value), 'PX', ttlMs);
+    } else {
+      await this.redis.set(redisKey, this.encode(value));
+    }
   }
 
   async deleteAuxByPrefix(

--- a/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
+++ b/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
@@ -1,0 +1,288 @@
+import type { Redis } from 'ioredis';
+import { EnvService, InstanceService } from '../../../shared/services';
+import { Logger } from '../../../shared/logger';
+import { SYSTEM_QUEUES } from '../../../shared/utils/constant';
+
+type Timer = ReturnType<typeof setInterval>;
+
+const DEFAULT_KEY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_LEASE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_RENEW_INTERVAL_MS = 60 * 1000;
+const DEFAULT_JANITOR_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_STALE_GRACE_MS = 24 * 60 * 60 * 1000;
+const SCAN_COUNT = 250;
+
+export interface RuntimeNamespaceCleanupResult {
+  namespace: string;
+  deleted: number;
+}
+
+export class RuntimeNamespaceLifecycleService {
+  private readonly logger = new Logger(RuntimeNamespaceLifecycleService.name);
+  private readonly redis: Redis;
+  private readonly envService: EnvService;
+  private readonly instanceService: InstanceService;
+  private readonly nodeName: string;
+  private readonly instanceId: string;
+  private readonly enabled: boolean;
+  private readonly keyTtlMs: number;
+  private readonly leaseTtlMs: number;
+  private readonly renewIntervalMs: number;
+  private readonly janitorIntervalMs: number;
+  private readonly staleGraceMs: number;
+  private renewTimer?: Timer;
+  private janitorTimer?: Timer;
+  private running = false;
+  private renewing = false;
+  private cleaning = false;
+
+  constructor(deps: {
+    redis: Redis;
+    envService: EnvService;
+    instanceService: InstanceService;
+  }) {
+    this.redis = deps.redis;
+    this.envService = deps.envService;
+    this.instanceService = deps.instanceService;
+    this.nodeName = deps.envService.get('NODE_NAME') || 'enfyra';
+    this.instanceId = deps.instanceService.getInstanceId();
+    this.enabled =
+      deps.envService.get('REDIS_NAMESPACE_LIFECYCLE_ENABLED') !== false;
+    this.keyTtlMs = this.readPositiveNumber(
+      'REDIS_NAMESPACE_KEY_TTL_MS',
+      DEFAULT_KEY_TTL_MS,
+    );
+    this.leaseTtlMs = this.readPositiveNumber(
+      'REDIS_NAMESPACE_LEASE_TTL_MS',
+      DEFAULT_LEASE_TTL_MS,
+    );
+    this.renewIntervalMs = this.readPositiveNumber(
+      'REDIS_NAMESPACE_RENEW_INTERVAL_MS',
+      Math.min(DEFAULT_RENEW_INTERVAL_MS, Math.max(1000, this.leaseTtlMs / 3)),
+    );
+    this.janitorIntervalMs = this.readPositiveNumber(
+      'REDIS_NAMESPACE_JANITOR_INTERVAL_MS',
+      DEFAULT_JANITOR_INTERVAL_MS,
+    );
+    this.staleGraceMs = this.readPositiveNumber(
+      'REDIS_NAMESPACE_STALE_GRACE_MS',
+      DEFAULT_STALE_GRACE_MS,
+    );
+  }
+
+  async init(): Promise<void> {
+    if (!this.enabled || this.running) return;
+    this.running = true;
+    await this.heartbeat();
+    await this.renewCurrentNamespaceKeys();
+    await this.cleanupStaleNamespaces();
+    this.renewTimer = setInterval(() => {
+      void this.renewCurrentNamespaceKeys();
+    }, this.renewIntervalMs);
+    this.janitorTimer = setInterval(() => {
+      void this.cleanupStaleNamespaces();
+    }, this.janitorIntervalMs);
+    this.renewTimer.unref?.();
+    this.janitorTimer.unref?.();
+  }
+
+  async onDestroy(): Promise<void> {
+    this.running = false;
+    if (this.renewTimer) clearInterval(this.renewTimer);
+    if (this.janitorTimer) clearInterval(this.janitorTimer);
+    this.renewTimer = undefined;
+    this.janitorTimer = undefined;
+    if (!this.enabled) return;
+    await this.redis.del(this.currentLeaseKey());
+  }
+
+  getKeyTtlMs(): number {
+    return this.keyTtlMs;
+  }
+
+  async touchKey(key: string, ttlMs = this.keyTtlMs): Promise<void> {
+    if (!this.enabled || ttlMs <= 0) return;
+    await this.redis.pexpire(key, ttlMs);
+  }
+
+  async touchKeys(keys: string[], ttlMs = this.keyTtlMs): Promise<void> {
+    if (!this.enabled || ttlMs <= 0 || keys.length === 0) return;
+    const pipeline = this.redis.pipeline();
+    for (const key of keys) pipeline.pexpire(key, ttlMs);
+    await pipeline.exec();
+  }
+
+  async renewCurrentNamespaceKeys(): Promise<void> {
+    if (!this.enabled || this.renewing) return;
+    this.renewing = true;
+    try {
+      await this.heartbeat();
+      for (const pattern of this.namespacePatterns(this.nodeName)) {
+        await this.expireByPattern(pattern, this.keyTtlMs);
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Runtime namespace renew failed: ${(error as Error).message}`,
+      );
+    } finally {
+      this.renewing = false;
+    }
+  }
+
+  async cleanupStaleNamespaces(
+    now = Date.now(),
+  ): Promise<RuntimeNamespaceCleanupResult[]> {
+    if (!this.enabled || this.cleaning) return [];
+    this.cleaning = true;
+    try {
+      const staleBefore = now - this.staleGraceMs;
+      const namespaces = await this.redis.zrangebyscore(
+        this.registryKey(),
+        0,
+        staleBefore,
+      );
+      const results: RuntimeNamespaceCleanupResult[] = [];
+      for (const namespace of namespaces) {
+        if (!namespace || namespace === this.nodeName) continue;
+        if (await this.hasActiveLease(namespace)) continue;
+        const deleted = await this.cleanupNamespace(namespace);
+        await this.redis.zrem(this.registryKey(), namespace);
+        await this.redis.del(this.namespaceMetaKey(namespace));
+        results.push({ namespace, deleted });
+      }
+      return results;
+    } catch (error) {
+      this.logger.warn(
+        `Runtime namespace cleanup failed: ${(error as Error).message}`,
+      );
+      return [];
+    } finally {
+      this.cleaning = false;
+    }
+  }
+
+  async cleanupNamespace(namespace: string): Promise<number> {
+    if (!this.enabled || !namespace || namespace === this.nodeName) return 0;
+    let deleted = 0;
+    for (const pattern of this.namespacePatterns(namespace)) {
+      deleted += await this.unlinkByPattern(pattern);
+    }
+    return deleted;
+  }
+
+  private async heartbeat(): Promise<void> {
+    const now = Date.now();
+    const payload = JSON.stringify({
+      namespace: this.nodeName,
+      instanceId: this.instanceId,
+      updatedAt: new Date(now).toISOString(),
+    });
+    await this.redis
+      .pipeline()
+      .set(this.currentLeaseKey(), payload, 'PX', this.leaseTtlMs)
+      .zadd(this.registryKey(), now, this.nodeName)
+      .hset(this.namespaceMetaKey(this.nodeName), {
+        namespace: this.nodeName,
+        updatedAt: new Date(now).toISOString(),
+      })
+      .pexpire(this.namespaceMetaKey(this.nodeName), this.keyTtlMs)
+      .pexpire(this.registryKey(), this.keyTtlMs)
+      .exec();
+  }
+
+  private async hasActiveLease(namespace: string): Promise<boolean> {
+    let cursor = '0';
+    const pattern = `${namespace}:runtime_lifecycle:lease:*`;
+    do {
+      const [nextCursor, keys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        SCAN_COUNT,
+      );
+      if (keys.length > 0) return true;
+      cursor = nextCursor;
+    } while (cursor !== '0');
+    return false;
+  }
+
+  private async expireByPattern(pattern: string, ttlMs: number): Promise<void> {
+    let cursor = '0';
+    do {
+      const [nextCursor, keys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        SCAN_COUNT,
+      );
+      await this.touchKeys(keys, ttlMs);
+      cursor = nextCursor;
+    } while (cursor !== '0');
+  }
+
+  private async unlinkByPattern(pattern: string): Promise<number> {
+    let cursor = '0';
+    let deleted = 0;
+    do {
+      const [nextCursor, keys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        SCAN_COUNT,
+      );
+      if (keys.length > 0) {
+        deleted += await this.unlinkKeys(keys);
+      }
+      cursor = nextCursor;
+    } while (cursor !== '0');
+    return deleted;
+  }
+
+  private async unlinkKeys(keys: string[]): Promise<number> {
+    const redisWithUnlink = this.redis as Redis & {
+      unlink?: (...keys: string[]) => Promise<number>;
+    };
+    if (typeof redisWithUnlink.unlink === 'function') {
+      return redisWithUnlink.unlink(...keys);
+    }
+    return this.redis.del(...keys);
+  }
+
+  private namespacePatterns(namespace: string): string[] {
+    return [
+      `${namespace}:runtime_lifecycle:*`,
+      `${namespace}:runtime_cache:*`,
+      `${namespace}:runtime-monitor:*`,
+      `${namespace}:cluster-telemetry:*`,
+      `${namespace}:user_cache:*`,
+      `${namespace}:user_cache_meta:*`,
+      `${namespace}:rl:*`,
+      `${namespace}:socket.io:*`,
+      `${namespace}:coord:sql:*`,
+      ...Object.values(SYSTEM_QUEUES).map((queue) => `${namespace}:${queue}:*`),
+    ];
+  }
+
+  private registryKey(): string {
+    return 'enfyra:runtime_namespaces';
+  }
+
+  private namespaceMetaKey(namespace: string): string {
+    return `enfyra:runtime_namespace:${namespace}`;
+  }
+
+  private currentLeaseKey(): string {
+    return `${this.nodeName}:runtime_lifecycle:lease:${this.instanceId}`;
+  }
+
+  private readPositiveNumber(
+    key: Parameters<EnvService['get']>[0],
+    fallback: number,
+  ): number {
+    const value = Number(this.envService.get(key));
+    return Number.isFinite(value) && value > 0 ? value : fallback;
+  }
+}

--- a/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
+++ b/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
@@ -5,18 +5,11 @@ import { SYSTEM_QUEUES } from '../../../shared/utils/constant';
 
 type Timer = ReturnType<typeof setInterval>;
 
-const DEFAULT_KEY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-const DEFAULT_LEASE_TTL_MS = 5 * 60 * 1000;
-const DEFAULT_RENEW_INTERVAL_MS = 60 * 1000;
-const DEFAULT_JANITOR_INTERVAL_MS = 5 * 60 * 1000;
-const DEFAULT_STALE_GRACE_MS = 24 * 60 * 60 * 1000;
-const MIN_KEY_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_KEY_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_LEASE_TTL_MS = 60 * 1000;
+const DEFAULT_RENEW_INTERVAL_MS = 20 * 1000;
+const MIN_KEY_TTL_MS = 5 * 60 * 1000;
 const SCAN_COUNT = 250;
-
-export interface RuntimeNamespaceCleanupResult {
-  namespace: string;
-  deleted: number;
-}
 
 export class RuntimeNamespaceLifecycleService {
   private readonly logger = new Logger(RuntimeNamespaceLifecycleService.name);
@@ -29,13 +22,9 @@ export class RuntimeNamespaceLifecycleService {
   private readonly keyTtlMs: number;
   private readonly leaseTtlMs: number;
   private readonly renewIntervalMs: number;
-  private readonly janitorIntervalMs: number;
-  private readonly staleGraceMs: number;
   private renewTimer?: Timer;
-  private janitorTimer?: Timer;
   private running = false;
   private renewing = false;
-  private cleaning = false;
 
   constructor(deps: {
     redis: Redis;
@@ -68,14 +57,6 @@ export class RuntimeNamespaceLifecycleService {
       ),
       Math.max(1000, Math.floor(this.keyTtlMs / 3)),
     );
-    this.janitorIntervalMs = this.readPositiveNumber(
-      'REDIS_NAMESPACE_JANITOR_INTERVAL_MS',
-      DEFAULT_JANITOR_INTERVAL_MS,
-    );
-    this.staleGraceMs = this.readPositiveNumber(
-      'REDIS_NAMESPACE_STALE_GRACE_MS',
-      DEFAULT_STALE_GRACE_MS,
-    );
   }
 
   async init(): Promise<void> {
@@ -83,23 +64,16 @@ export class RuntimeNamespaceLifecycleService {
     this.running = true;
     await this.heartbeat();
     await this.renewCurrentNamespaceKeys();
-    await this.cleanupStaleNamespaces();
     this.renewTimer = setInterval(() => {
       void this.renewCurrentNamespaceKeys();
     }, this.renewIntervalMs);
-    this.janitorTimer = setInterval(() => {
-      void this.cleanupStaleNamespaces();
-    }, this.janitorIntervalMs);
     this.renewTimer.unref?.();
-    this.janitorTimer.unref?.();
   }
 
   async onDestroy(): Promise<void> {
     this.running = false;
     if (this.renewTimer) clearInterval(this.renewTimer);
-    if (this.janitorTimer) clearInterval(this.janitorTimer);
     this.renewTimer = undefined;
-    this.janitorTimer = undefined;
     if (!this.enabled) return;
     await this.redis.del(this.currentLeaseKey());
   }
@@ -159,47 +133,6 @@ export class RuntimeNamespaceLifecycleService {
     }
   }
 
-  async cleanupStaleNamespaces(
-    now = Date.now(),
-  ): Promise<RuntimeNamespaceCleanupResult[]> {
-    if (!this.enabled || this.cleaning) return [];
-    this.cleaning = true;
-    try {
-      const staleBefore = now - this.staleGraceMs;
-      const namespaces = await this.redis.zrangebyscore(
-        this.registryKey(),
-        0,
-        staleBefore,
-      );
-      const results: RuntimeNamespaceCleanupResult[] = [];
-      for (const namespace of namespaces) {
-        if (!namespace || namespace === this.nodeName) continue;
-        if (await this.hasActiveLease(namespace)) continue;
-        const deleted = await this.cleanupNamespace(namespace);
-        await this.redis.zrem(this.registryKey(), namespace);
-        await this.redis.del(this.namespaceMetaKey(namespace));
-        results.push({ namespace, deleted });
-      }
-      return results;
-    } catch (error) {
-      this.logger.warn(
-        `Runtime namespace cleanup failed: ${(error as Error).message}`,
-      );
-      return [];
-    } finally {
-      this.cleaning = false;
-    }
-  }
-
-  async cleanupNamespace(namespace: string): Promise<number> {
-    if (!this.enabled || !namespace || namespace === this.nodeName) return 0;
-    let deleted = 0;
-    for (const pattern of this.cleanupNamespacePatterns(namespace)) {
-      deleted += await this.unlinkByPattern(pattern);
-    }
-    return deleted;
-  }
-
   private async heartbeat(): Promise<void> {
     const now = Date.now();
     const payload = JSON.stringify({
@@ -210,31 +143,7 @@ export class RuntimeNamespaceLifecycleService {
     await this.redis
       .pipeline()
       .set(this.currentLeaseKey(), payload, 'PX', this.leaseTtlMs)
-      .zadd(this.registryKey(), now, this.nodeName)
-      .hset(this.namespaceMetaKey(this.nodeName), {
-        namespace: this.nodeName,
-        updatedAt: new Date(now).toISOString(),
-      })
-      .pexpire(this.namespaceMetaKey(this.nodeName), this.keyTtlMs)
-      .pexpire(this.registryKey(), this.keyTtlMs)
       .exec();
-  }
-
-  private async hasActiveLease(namespace: string): Promise<boolean> {
-    let cursor = '0';
-    const pattern = `${namespace}:runtime_lifecycle:lease:*`;
-    do {
-      const [nextCursor, keys] = await this.redis.scan(
-        cursor,
-        'MATCH',
-        pattern,
-        'COUNT',
-        SCAN_COUNT,
-      );
-      if (keys.length > 0) return true;
-      cursor = nextCursor;
-    } while (cursor !== '0');
-    return false;
   }
 
   private async expireByPattern(pattern: string, ttlMs: number): Promise<void> {
@@ -252,35 +161,6 @@ export class RuntimeNamespaceLifecycleService {
     } while (cursor !== '0');
   }
 
-  private async unlinkByPattern(pattern: string): Promise<number> {
-    let cursor = '0';
-    let deleted = 0;
-    do {
-      const [nextCursor, keys] = await this.redis.scan(
-        cursor,
-        'MATCH',
-        pattern,
-        'COUNT',
-        SCAN_COUNT,
-      );
-      if (keys.length > 0) {
-        deleted += await this.unlinkKeys(keys);
-      }
-      cursor = nextCursor;
-    } while (cursor !== '0');
-    return deleted;
-  }
-
-  private async unlinkKeys(keys: string[]): Promise<number> {
-    const redisWithUnlink = this.redis as Redis & {
-      unlink?: (...keys: string[]) => Promise<number>;
-    };
-    if (typeof redisWithUnlink.unlink === 'function') {
-      return redisWithUnlink.unlink(...keys);
-    }
-    return this.redis.del(...keys);
-  }
-
   private renewableNamespacePatterns(namespace: string): string[] {
     return [
       `${namespace}:runtime_lifecycle:*`,
@@ -294,18 +174,6 @@ export class RuntimeNamespaceLifecycleService {
       `${namespace}:coord:sql:*`,
       ...Object.values(SYSTEM_QUEUES).map((queue) => `${namespace}:${queue}:*`),
     ];
-  }
-
-  private cleanupNamespacePatterns(namespace: string): string[] {
-    return this.renewableNamespacePatterns(namespace);
-  }
-
-  private registryKey(): string {
-    return 'enfyra:runtime_namespaces';
-  }
-
-  private namespaceMetaKey(namespace: string): string {
-    return `enfyra:runtime_namespace:${namespace}`;
   }
 
   private currentLeaseKey(): string {

--- a/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
+++ b/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
@@ -10,6 +10,7 @@ const DEFAULT_LEASE_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_RENEW_INTERVAL_MS = 60 * 1000;
 const DEFAULT_JANITOR_INTERVAL_MS = 5 * 60 * 1000;
 const DEFAULT_STALE_GRACE_MS = 24 * 60 * 60 * 1000;
+const MIN_KEY_TTL_MS = 24 * 60 * 60 * 1000;
 const SCAN_COUNT = 250;
 
 export interface RuntimeNamespaceCleanupResult {
@@ -51,14 +52,21 @@ export class RuntimeNamespaceLifecycleService {
     this.keyTtlMs = this.readPositiveNumber(
       'REDIS_NAMESPACE_KEY_TTL_MS',
       DEFAULT_KEY_TTL_MS,
+      MIN_KEY_TTL_MS,
     );
     this.leaseTtlMs = this.readPositiveNumber(
       'REDIS_NAMESPACE_LEASE_TTL_MS',
       DEFAULT_LEASE_TTL_MS,
     );
-    this.renewIntervalMs = this.readPositiveNumber(
-      'REDIS_NAMESPACE_RENEW_INTERVAL_MS',
-      Math.min(DEFAULT_RENEW_INTERVAL_MS, Math.max(1000, this.leaseTtlMs / 3)),
+    this.renewIntervalMs = Math.min(
+      this.readPositiveNumber(
+        'REDIS_NAMESPACE_RENEW_INTERVAL_MS',
+        Math.min(
+          DEFAULT_RENEW_INTERVAL_MS,
+          Math.max(1000, this.leaseTtlMs / 3),
+        ),
+      ),
+      Math.max(1000, Math.floor(this.keyTtlMs / 3)),
     );
     this.janitorIntervalMs = this.readPositiveNumber(
       'REDIS_NAMESPACE_JANITOR_INTERVAL_MS',
@@ -117,7 +125,7 @@ export class RuntimeNamespaceLifecycleService {
     this.renewing = true;
     try {
       await this.heartbeat();
-      for (const pattern of this.namespacePatterns(this.nodeName)) {
+      for (const pattern of this.renewableNamespacePatterns(this.nodeName)) {
         await this.expireByPattern(pattern, this.keyTtlMs);
       }
     } catch (error) {
@@ -164,7 +172,7 @@ export class RuntimeNamespaceLifecycleService {
   async cleanupNamespace(namespace: string): Promise<number> {
     if (!this.enabled || !namespace || namespace === this.nodeName) return 0;
     let deleted = 0;
-    for (const pattern of this.namespacePatterns(namespace)) {
+    for (const pattern of this.cleanupNamespacePatterns(namespace)) {
       deleted += await this.unlinkByPattern(pattern);
     }
     return deleted;
@@ -251,7 +259,7 @@ export class RuntimeNamespaceLifecycleService {
     return this.redis.del(...keys);
   }
 
-  private namespacePatterns(namespace: string): string[] {
+  private renewableNamespacePatterns(namespace: string): string[] {
     return [
       `${namespace}:runtime_lifecycle:*`,
       `${namespace}:runtime_cache:*`,
@@ -264,6 +272,10 @@ export class RuntimeNamespaceLifecycleService {
       `${namespace}:coord:sql:*`,
       ...Object.values(SYSTEM_QUEUES).map((queue) => `${namespace}:${queue}:*`),
     ];
+  }
+
+  private cleanupNamespacePatterns(namespace: string): string[] {
+    return this.renewableNamespacePatterns(namespace);
   }
 
   private registryKey(): string {
@@ -281,8 +293,11 @@ export class RuntimeNamespaceLifecycleService {
   private readPositiveNumber(
     key: Parameters<EnvService['get']>[0],
     fallback: number,
+    minValue = 1,
   ): number {
     const value = Number(this.envService.get(key));
-    return Number.isFinite(value) && value > 0 ? value : fallback;
+    if (!Number.isFinite(value) || value <= 0) return fallback;
+    if (this.envService.get('NODE_ENV') === 'test') return value;
+    return Math.max(value, minValue);
   }
 }

--- a/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
+++ b/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
@@ -120,6 +120,28 @@ export class RuntimeNamespaceLifecycleService {
     await pipeline.exec();
   }
 
+  async renewKeysByPattern(
+    pattern: string,
+    ttlMs = this.keyTtlMs,
+  ): Promise<void> {
+    if (!this.enabled || ttlMs <= 0 || !pattern) return;
+    try {
+      await this.expireByPattern(pattern, ttlMs);
+    } catch (error) {
+      this.logger.warn(
+        `Runtime namespace pattern renew failed for ${pattern}: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  async renewSystemQueueKeys(queueName: string): Promise<void> {
+    if (!this.enabled || !queueName) return;
+    await this.renewKeysByPattern(
+      `${this.nodeName}:${queueName}:*`,
+      this.keyTtlMs,
+    );
+  }
+
   async renewCurrentNamespaceKeys(): Promise<void> {
     if (!this.enabled || this.renewing) return;
     this.renewing = true;

--- a/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
+++ b/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
@@ -18,7 +18,6 @@ export class RuntimeNamespaceLifecycleService {
   private readonly instanceService: InstanceService;
   private readonly nodeName: string;
   private readonly instanceId: string;
-  private readonly enabled: boolean;
   private readonly keyTtlMs: number;
   private readonly leaseTtlMs: number;
   private readonly renewIntervalMs: number;
@@ -36,8 +35,6 @@ export class RuntimeNamespaceLifecycleService {
     this.instanceService = deps.instanceService;
     this.nodeName = deps.envService.get('NODE_NAME') || 'enfyra';
     this.instanceId = deps.instanceService.getInstanceId();
-    this.enabled =
-      deps.envService.get('REDIS_NAMESPACE_LIFECYCLE_ENABLED') !== false;
     this.keyTtlMs = this.readPositiveNumber(
       'REDIS_NAMESPACE_KEY_TTL_MS',
       DEFAULT_KEY_TTL_MS,
@@ -60,7 +57,7 @@ export class RuntimeNamespaceLifecycleService {
   }
 
   async init(): Promise<void> {
-    if (!this.enabled || this.running) return;
+    if (this.running) return;
     this.running = true;
     await this.heartbeat();
     await this.renewCurrentNamespaceKeys();
@@ -74,7 +71,6 @@ export class RuntimeNamespaceLifecycleService {
     this.running = false;
     if (this.renewTimer) clearInterval(this.renewTimer);
     this.renewTimer = undefined;
-    if (!this.enabled) return;
     await this.redis.del(this.currentLeaseKey());
   }
 
@@ -83,12 +79,12 @@ export class RuntimeNamespaceLifecycleService {
   }
 
   async touchKey(key: string, ttlMs = this.keyTtlMs): Promise<void> {
-    if (!this.enabled || ttlMs <= 0) return;
+    if (ttlMs <= 0) return;
     await this.redis.pexpire(key, ttlMs);
   }
 
   async touchKeys(keys: string[], ttlMs = this.keyTtlMs): Promise<void> {
-    if (!this.enabled || ttlMs <= 0 || keys.length === 0) return;
+    if (ttlMs <= 0 || keys.length === 0) return;
     const pipeline = this.redis.pipeline();
     for (const key of keys) pipeline.pexpire(key, ttlMs);
     await pipeline.exec();
@@ -98,7 +94,7 @@ export class RuntimeNamespaceLifecycleService {
     pattern: string,
     ttlMs = this.keyTtlMs,
   ): Promise<void> {
-    if (!this.enabled || ttlMs <= 0 || !pattern) return;
+    if (ttlMs <= 0 || !pattern) return;
     try {
       await this.expireByPattern(pattern, ttlMs);
     } catch (error) {
@@ -109,7 +105,7 @@ export class RuntimeNamespaceLifecycleService {
   }
 
   async renewSystemQueueKeys(queueName: string): Promise<void> {
-    if (!this.enabled || !queueName) return;
+    if (!queueName) return;
     await this.renewKeysByPattern(
       `${this.nodeName}:${queueName}:*`,
       this.keyTtlMs,
@@ -117,7 +113,7 @@ export class RuntimeNamespaceLifecycleService {
   }
 
   async renewCurrentNamespaceKeys(): Promise<void> {
-    if (!this.enabled || this.renewing) return;
+    if (this.renewing) return;
     this.renewing = true;
     try {
       await this.heartbeat();

--- a/src/engines/cache/services/user-cache.service.ts
+++ b/src/engines/cache/services/user-cache.service.ts
@@ -93,18 +93,12 @@ export class UserCacheService implements ICache {
     if (ttlMs > 0) {
       await this.redis.set(decoratedKey, serializedValue, 'PX', ttlMs);
     } else {
-      const namespaceTtlMs =
-        this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
-      if (namespaceTtlMs && namespaceTtlMs > 0) {
-        await this.redis.set(
-          decoratedKey,
-          serializedValue,
-          'PX',
-          namespaceTtlMs,
-        );
-      } else {
-        await this.redis.set(decoratedKey, serializedValue);
-      }
+      await this.redis.set(
+        decoratedKey,
+        serializedValue,
+        'PX',
+        this.lifecycleTtlMs(),
+      );
     }
     await this.track(decoratedKey, size);
     await this.evictIfNeeded();
@@ -150,7 +144,8 @@ export class UserCacheService implements ICache {
   }
 
   private decorateKey(key: string): string {
-    if (!key || typeof key !== 'string') throw new Error('cache key is required');
+    if (!key || typeof key !== 'string')
+      throw new Error('cache key is required');
     if (key.startsWith(this.dataPrefix())) return key;
     return `${this.dataPrefix()}${key}`;
   }
@@ -244,7 +239,9 @@ export class UserCacheService implements ICache {
     while (total > this.limitBytes) {
       const [oldest] = await this.redis.zrange(this.lruKey(), 0, 0);
       if (!oldest) break;
-      const size = Number((await this.redis.hget(this.sizesKey(), oldest)) ?? 0);
+      const size = Number(
+        (await this.redis.hget(this.sizesKey(), oldest)) ?? 0,
+      );
       await this.redis
         .pipeline()
         .del(oldest)
@@ -254,5 +251,13 @@ export class UserCacheService implements ICache {
         .exec();
       total -= size;
     }
+  }
+
+  private lifecycleTtlMs(): number {
+    const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
+    if (!ttlMs || ttlMs <= 0) {
+      throw new Error('Runtime namespace lifecycle TTL is required');
+    }
+    return ttlMs;
   }
 }

--- a/src/engines/cache/services/user-cache.service.ts
+++ b/src/engines/cache/services/user-cache.service.ts
@@ -38,7 +38,7 @@ export class UserCacheService implements ICache {
       decoratedKey,
       serializedValue,
       'PX',
-      ttlMs,
+      ttlMs > 0 ? ttlMs : this.lifecycleTtlMs(),
       'NX',
     );
     if (result !== 'OK') {
@@ -200,37 +200,30 @@ export class UserCacheService implements ICache {
   }
 
   private async touch(key: string): Promise<void> {
-    await this.redis.zadd(this.lruKey(), Date.now(), key);
-    await this.runtimeNamespaceLifecycleService?.touchKeys([
-      this.lruKey(),
-      this.sizesKey(),
-      this.totalKey(),
-    ]);
+    const pipeline = this.redisTransaction();
+    pipeline.zadd(this.lruKey(), Date.now(), key);
+    this.touchMetadataKeys(pipeline);
+    await pipeline.exec();
   }
 
   private async track(key: string, size: number): Promise<void> {
     const oldSize = Number((await this.redis.hget(this.sizesKey(), key)) ?? 0);
-    await this.redis
-      .pipeline()
-      .hset(this.sizesKey(), key, size)
-      .incrby(this.totalKey(), size - oldSize)
-      .zadd(this.lruKey(), Date.now(), key)
-      .exec();
-    await this.runtimeNamespaceLifecycleService?.touchKeys([
-      this.lruKey(),
-      this.sizesKey(),
-      this.totalKey(),
-    ]);
+    const pipeline = this.redisTransaction();
+    pipeline.hset(this.sizesKey(), key, size);
+    pipeline.incrby(this.totalKey(), size - oldSize);
+    pipeline.zadd(this.lruKey(), Date.now(), key);
+    this.touchMetadataKeys(pipeline);
+    await pipeline.exec();
   }
 
   private async untrack(key: string): Promise<void> {
     const oldSize = Number((await this.redis.hget(this.sizesKey(), key)) ?? 0);
-    await this.redis
-      .pipeline()
-      .hdel(this.sizesKey(), key)
-      .zrem(this.lruKey(), key)
-      .incrby(this.totalKey(), -oldSize)
-      .exec();
+    const pipeline = this.redisTransaction();
+    pipeline.hdel(this.sizesKey(), key);
+    pipeline.zrem(this.lruKey(), key);
+    if (oldSize !== 0) pipeline.incrby(this.totalKey(), -oldSize);
+    this.touchMetadataKeys(pipeline);
+    await pipeline.exec();
   }
 
   private async evictIfNeeded(): Promise<void> {
@@ -242,13 +235,13 @@ export class UserCacheService implements ICache {
       const size = Number(
         (await this.redis.hget(this.sizesKey(), oldest)) ?? 0,
       );
-      await this.redis
-        .pipeline()
-        .del(oldest)
-        .hdel(this.sizesKey(), oldest)
-        .zrem(this.lruKey(), oldest)
-        .incrby(this.totalKey(), -size)
-        .exec();
+      const pipeline = this.redisTransaction();
+      pipeline.del(oldest);
+      pipeline.hdel(this.sizesKey(), oldest);
+      pipeline.zrem(this.lruKey(), oldest);
+      if (size !== 0) pipeline.incrby(this.totalKey(), -size);
+      this.touchMetadataKeys(pipeline);
+      await pipeline.exec();
       total -= size;
     }
   }
@@ -259,5 +252,24 @@ export class UserCacheService implements ICache {
       throw new Error('Runtime namespace lifecycle TTL is required');
     }
     return ttlMs;
+  }
+
+  private redisTransaction(): ReturnType<Redis['pipeline']> {
+    const redis = this.redis as Redis & {
+      multi?: () => ReturnType<Redis['pipeline']>;
+    };
+    return typeof redis.multi === 'function'
+      ? redis.multi()
+      : this.redis.pipeline();
+  }
+
+  private touchMetadataKeys(pipeline: ReturnType<Redis['pipeline']>): void {
+    if (!this.runtimeNamespaceLifecycleService) {
+      throw new Error('Runtime namespace lifecycle TTL is required');
+    }
+    const ttlMs = this.lifecycleTtlMs();
+    pipeline.pexpire(this.lruKey(), ttlMs);
+    pipeline.pexpire(this.sizesKey(), ttlMs);
+    pipeline.pexpire(this.totalKey(), ttlMs);
   }
 }

--- a/src/engines/cache/services/user-cache.service.ts
+++ b/src/engines/cache/services/user-cache.service.ts
@@ -1,16 +1,24 @@
 import { Redis } from 'ioredis';
 import { EnvService } from '../../../shared/services';
 import { ICache } from '../../../domain/shared/interfaces/cache.interface';
+import { RuntimeNamespaceLifecycleService } from './runtime-namespace-lifecycle.service';
 
 export class UserCacheService implements ICache {
   private readonly redis: Redis;
   private readonly nodeName: string;
   private readonly limitBytes: number;
   private readonly maxValueBytes: number;
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
 
-  constructor(deps: { redis: Redis; envService: EnvService }) {
+  constructor(deps: {
+    redis: Redis;
+    envService: EnvService;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
+  }) {
     this.redis = deps.redis;
     this.nodeName = deps.envService.get('NODE_NAME') || 'enfyra';
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
     this.limitBytes =
       Number(deps.envService.get('REDIS_USER_CACHE_LIMIT_MB') || 0) *
       1024 *
@@ -85,7 +93,18 @@ export class UserCacheService implements ICache {
     if (ttlMs > 0) {
       await this.redis.set(decoratedKey, serializedValue, 'PX', ttlMs);
     } else {
-      await this.redis.set(decoratedKey, serializedValue);
+      const namespaceTtlMs =
+        this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
+      if (namespaceTtlMs && namespaceTtlMs > 0) {
+        await this.redis.set(
+          decoratedKey,
+          serializedValue,
+          'PX',
+          namespaceTtlMs,
+        );
+      } else {
+        await this.redis.set(decoratedKey, serializedValue);
+      }
     }
     await this.track(decoratedKey, size);
     await this.evictIfNeeded();
@@ -187,6 +206,11 @@ export class UserCacheService implements ICache {
 
   private async touch(key: string): Promise<void> {
     await this.redis.zadd(this.lruKey(), Date.now(), key);
+    await this.runtimeNamespaceLifecycleService?.touchKeys([
+      this.lruKey(),
+      this.sizesKey(),
+      this.totalKey(),
+    ]);
   }
 
   private async track(key: string, size: number): Promise<void> {
@@ -197,6 +221,11 @@ export class UserCacheService implements ICache {
       .incrby(this.totalKey(), size - oldSize)
       .zadd(this.lruKey(), Date.now(), key)
       .exec();
+    await this.runtimeNamespaceLifecycleService?.touchKeys([
+      this.lruKey(),
+      this.sizesKey(),
+      this.totalKey(),
+    ]);
   }
 
   private async untrack(key: string): Promise<void> {

--- a/src/engines/knex/services/sql-pool-cluster-coordinator.service.ts
+++ b/src/engines/knex/services/sql-pool-cluster-coordinator.service.ts
@@ -39,6 +39,10 @@ export class SqlPoolClusterCoordinatorService {
   private readonly knexService: KnexService;
   private readonly eventEmitter: EventEmitter2;
   private readonly replicationManager?: ReplicationManager;
+  private readonly coordinationKeyTtlMs = Math.max(
+    SQL_COORD_STALE_MS * 2,
+    SQL_COORD_HEARTBEAT_MS * 5,
+  );
 
   constructor(deps: {
     redis: Redis;
@@ -138,7 +142,11 @@ export class SqlPoolClusterCoordinatorService {
       return;
     }
     try {
-      await this.redis.zadd(this.zsetKey, Date.now(), this.instanceId);
+      await this.redis
+        .pipeline()
+        .zadd(this.zsetKey, Date.now(), this.instanceId)
+        .pexpire(this.zsetKey, this.coordinationKeyTtlMs)
+        .exec();
     } catch (e) {
       this.logger.warn(
         `Pool coordination heartbeat failed: ${(e as Error).message}`,
@@ -156,6 +164,7 @@ export class SqlPoolClusterCoordinatorService {
       '-inf',
       now - SQL_COORD_STALE_MS,
     );
+    await this.redis.pexpire(this.zsetKey, this.coordinationKeyTtlMs);
     const n = await this.redis.zcard(this.zsetKey);
     return Math.max(1, n);
   }
@@ -209,6 +218,7 @@ export class SqlPoolClusterCoordinatorService {
       '-inf',
       now - SQL_COORD_STALE_MS,
     );
+    await this.redis.pexpire(this.zsetKey, this.coordinationKeyTtlMs);
     const rows = await this.redis.zrange(this.zsetKey, 0, -1, 'WITHSCORES');
     const instances: Array<{
       id: string;

--- a/src/engines/knex/services/sql-pool-cluster-coordinator.service.ts
+++ b/src/engines/knex/services/sql-pool-cluster-coordinator.service.ts
@@ -142,11 +142,10 @@ export class SqlPoolClusterCoordinatorService {
       return;
     }
     try {
-      await this.redis
-        .pipeline()
-        .zadd(this.zsetKey, Date.now(), this.instanceId)
-        .pexpire(this.zsetKey, this.coordinationKeyTtlMs)
-        .exec();
+      const pipeline = this.redisTransaction(this.redis);
+      pipeline.zadd(this.zsetKey, Date.now(), this.instanceId);
+      pipeline.pexpire(this.zsetKey, this.coordinationKeyTtlMs);
+      await pipeline.exec();
     } catch (e) {
       this.logger.warn(
         `Pool coordination heartbeat failed: ${(e as Error).message}`,
@@ -338,5 +337,14 @@ export class SqlPoolClusterCoordinatorService {
         `Pool coordination reconcile failed: ${(e as Error).message}`,
       );
     }
+  }
+
+  private redisTransaction(redis: Redis): ReturnType<Redis['pipeline']> {
+    const client = redis as Redis & {
+      multi?: () => ReturnType<Redis['pipeline']>;
+    };
+    return typeof client.multi === 'function'
+      ? client.multi()
+      : redis.pipeline();
   }
 }

--- a/src/engines/mongo/services/mongo-physical-migration.service.ts
+++ b/src/engines/mongo/services/mongo-physical-migration.service.ts
@@ -2,13 +2,11 @@ import { randomUUID } from 'crypto';
 import { Worker, type Job, type Queue } from 'bullmq';
 import type { Db } from 'mongodb';
 import { Logger } from '../../../shared/logger';
-import {
-  DatabaseConfigService,
-  EnvService,
-} from '../../../shared/services';
+import { DatabaseConfigService, EnvService } from '../../../shared/services';
 import { SYSTEM_QUEUES } from '../../../shared/utils/constant';
 import { getErrorMessage } from '../../../shared/utils/error.util';
 import { MongoService } from './mongo.service';
+import type { RuntimeNamespaceLifecycleService } from '../../cache/services/runtime-namespace-lifecycle.service';
 
 type MongoPhysicalMigrationStatus =
   | 'pending'
@@ -50,6 +48,7 @@ export class MongoPhysicalMigrationService {
   private readonly databaseConfigService: DatabaseConfigService;
   private readonly envService: EnvService;
   private readonly queue: Queue;
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
   private worker?: Worker;
   private activeRenameCache = new Map<
     string,
@@ -61,11 +60,14 @@ export class MongoPhysicalMigrationService {
     databaseConfigService: DatabaseConfigService;
     envService: EnvService;
     mongoPhysicalMigrationQueue: Queue;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
   }) {
     this.mongoService = deps.mongoService;
     this.databaseConfigService = deps.databaseConfigService;
     this.envService = deps.envService;
     this.queue = deps.mongoPhysicalMigrationQueue;
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
   }
 
   async init(): Promise<void> {
@@ -116,7 +118,11 @@ export class MongoPhysicalMigrationService {
 
     const collection = this.collection();
     for (const rename of renames) {
-      if (!rename.oldName || !rename.newName || rename.oldName === rename.newName) {
+      if (
+        !rename.oldName ||
+        !rename.newName ||
+        rename.oldName === rename.newName
+      ) {
         continue;
       }
       const now = new Date().toISOString();
@@ -156,6 +162,9 @@ export class MongoPhysicalMigrationService {
           removeOnComplete: true,
           removeOnFail: 100,
         },
+      );
+      await this.runtimeNamespaceLifecycleService?.renewSystemQueueKeys(
+        SYSTEM_QUEUES.MONGO_PHYSICAL_MIGRATION,
       );
     }
     this.invalidateActiveRenameCache(tableName);
@@ -240,7 +249,10 @@ export class MongoPhysicalMigrationService {
     for (const row of rows) {
       if (!row || typeof row !== 'object') continue;
       for (const rename of renames) {
-        if (row[rename.newName] === undefined && row[rename.oldName] !== undefined) {
+        if (
+          row[rename.newName] === undefined &&
+          row[rename.oldName] !== undefined
+        ) {
           row[rename.newName] = row[rename.oldName];
         }
         if (hidden.has(rename.oldName) || row[rename.newName] !== undefined) {
@@ -296,7 +308,9 @@ export class MongoPhysicalMigrationService {
   private async renameFieldInBatches(
     migration: MongoFieldRenameMigration,
   ): Promise<{ processed: number; conflictCount: number }> {
-    const collection = this.mongoService.getDb().collection(migration.tableName);
+    const collection = this.mongoService
+      .getDb()
+      .collection(migration.tableName);
     let processed = migration.processed || 0;
     let conflictCount = migration.conflictCount || 0;
     let lastId: any;

--- a/src/env.ts
+++ b/src/env.ts
@@ -35,27 +35,9 @@ const EnvSchema = z.object({
     .optional()
     .default('true')
     .transform((v) => v === 'true'),
-  REDIS_NAMESPACE_KEY_TTL_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .optional(),
-  REDIS_NAMESPACE_LEASE_TTL_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .optional(),
+  REDIS_NAMESPACE_KEY_TTL_MS: z.coerce.number().int().positive().optional(),
+  REDIS_NAMESPACE_LEASE_TTL_MS: z.coerce.number().int().positive().optional(),
   REDIS_NAMESPACE_RENEW_INTERVAL_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .optional(),
-  REDIS_NAMESPACE_JANITOR_INTERVAL_MS: z.coerce
-    .number()
-    .int()
-    .positive()
-    .optional(),
-  REDIS_NAMESPACE_STALE_GRACE_MS: z.coerce
     .number()
     .int()
     .positive()

--- a/src/env.ts
+++ b/src/env.ts
@@ -30,6 +30,36 @@ const EnvSchema = z.object({
     .min(0)
     .optional()
     .default(0),
+  REDIS_NAMESPACE_LIFECYCLE_ENABLED: z
+    .enum(['true', 'false'])
+    .optional()
+    .default('true')
+    .transform((v) => v === 'true'),
+  REDIS_NAMESPACE_KEY_TTL_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional(),
+  REDIS_NAMESPACE_LEASE_TTL_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional(),
+  REDIS_NAMESPACE_RENEW_INTERVAL_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional(),
+  REDIS_NAMESPACE_JANITOR_INTERVAL_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional(),
+  REDIS_NAMESPACE_STALE_GRACE_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional(),
   ASSET_CACHE_MEMORY_PRESSURE_RATIO: z.coerce
     .number()
     .min(0)

--- a/src/env.ts
+++ b/src/env.ts
@@ -30,11 +30,6 @@ const EnvSchema = z.object({
     .min(0)
     .optional()
     .default(0),
-  REDIS_NAMESPACE_LIFECYCLE_ENABLED: z
-    .enum(['true', 'false'])
-    .optional()
-    .default('true')
-    .transform((v) => v === 'true'),
   REDIS_NAMESPACE_KEY_TTL_MS: z.coerce.number().int().positive().optional(),
   REDIS_NAMESPACE_LEASE_TTL_MS: z.coerce.number().int().positive().optional(),
   REDIS_NAMESPACE_RENEW_INTERVAL_MS: z.coerce

--- a/src/http/routes/admin.routes.ts
+++ b/src/http/routes/admin.routes.ts
@@ -296,6 +296,7 @@ export function registerAdminRoutes(
         cursor: req.query?.cursor,
         pattern: req.query?.pattern,
         count: req.query?.count,
+        filter: req.query?.filter,
       }),
     });
   });

--- a/src/init.ts
+++ b/src/init.ts
@@ -45,6 +45,9 @@ export async function init(container: AwilixContainer<Cradle>): Promise<void> {
   await runInitStep('redisPubSubService.init', () =>
     c.redisPubSubService?.init?.(),
   );
+  await runInitStep('runtimeNamespaceLifecycleService.init', () =>
+    c.runtimeNamespaceLifecycleService?.init?.(),
+  );
 
   try {
     await runInitStep('mongoSagaCoordinator.init', () =>
@@ -186,6 +189,9 @@ export async function init(container: AwilixContainer<Cradle>): Promise<void> {
       c.mongoPhysicalMigrationService?.init?.(),
     ),
   ]);
+  await runInitStep('runtimeNamespaceLifecycleService.renewReadyNamespace', () =>
+    c.runtimeNamespaceLifecycleService?.renewCurrentNamespaceKeys?.(),
+  );
 
   c.eventEmitter.emit(CACHE_EVENTS.SYSTEM_READY);
   logger.log('Init event emitted: SYSTEM_READY');

--- a/src/modules/admin/services/redis-admin.service.ts
+++ b/src/modules/admin/services/redis-admin.service.ts
@@ -14,6 +14,7 @@ import type {
   RedisAdminNamespaceScope,
   RedisAdminOverview,
   RedisAdminSeverity,
+  RedisAdminSystemKind,
   RedisAdminSystemMark,
   RedisAdminValueType,
 } from '../types';
@@ -77,8 +78,12 @@ export class RedisAdminService {
         .map((key) => this.describeKey(key)),
     );
     const summaries = allSummaries;
+    const currentSummaries = summaries.filter((summary) => summary.namespaceScope === 'current');
+    const browserSummaries = currentSummaries.filter(
+      (summary) => !this.isTransientKey(summary),
+    );
 
-    for (const summary of summaries) {
+    for (const summary of currentSummaries) {
       const group = this.groupKey(summary);
       const current =
         groups.get(group.name) ??
@@ -100,14 +105,14 @@ export class RedisAdminService {
     return {
       connected: true,
       health: this.evaluateHealth(server),
-      keyCount: summaries.length,
+      keyCount: browserSummaries.length,
       scanned: keys.scanned,
       scanComplete: keys.complete,
       server,
       keyspace: this.parseInfoSection(keyspace),
       userCache: await this.getUserCacheQuota(),
       groups: [...groups.values()].sort((a, b) => b.count - a.count),
-      topKeys: summaries
+      topKeys: browserSummaries
         .filter((item) => item.memoryBytes != null)
         .sort((a, b) => (b.memoryBytes ?? 0) - (a.memoryBytes ?? 0))
         .slice(0, 20),
@@ -118,6 +123,7 @@ export class RedisAdminService {
     cursor?: string;
     pattern?: string;
     count?: number;
+    filter?: RedisAdminSystemKind | 'custom' | 'all';
   }): Promise<{
     cursor: string;
     count: number;
@@ -129,16 +135,24 @@ export class RedisAdminService {
       MAX_SCAN_COUNT,
     );
     const pattern = this.effectiveListPattern(options.pattern);
-    const [cursor, keys] = await this.redis.scan(
-      options.cursor || '0',
-      'MATCH',
-      pattern,
-      'COUNT',
-      count,
-    );
-
-    const summaries = await Promise.all(keys.map((key) => this.describeKey(key)));
-    const readable = summaries.filter((key) => key.namespaceScope === 'current');
+    let cursor = options.cursor || '0';
+    const readable: RedisAdminKeySummary[] = [];
+    do {
+      const [nextCursor, keys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        count,
+      );
+      cursor = nextCursor;
+      const summaries = await Promise.all(keys.map((key) => this.describeKey(key)));
+      readable.push(
+        ...summaries.filter((key) =>
+          key.namespaceScope === 'current' && this.matchesListFilter(key, options.filter),
+        ),
+      );
+    } while (cursor !== '0' && readable.length < count);
     return {
       cursor,
       count: readable.length,
@@ -261,12 +275,20 @@ export class RedisAdminService {
         reason: '$cache user data',
       };
     }
-    if (key.startsWith('coord:sql:pool:')) {
+    if (key.startsWith(`${this.nodeName}:coord:sql:pool:`) || key.startsWith('coord:sql:pool:')) {
       return {
         isSystem: true,
         modifiable: false,
         systemKind: 'sql_pool_coordination',
         reason: 'SQL pool coordination',
+      };
+    }
+    if (key.startsWith(`${this.nodeName}:rl:`) || key.startsWith('rl:')) {
+      return {
+        isSystem: true,
+        modifiable: false,
+        systemKind: 'rate_limit',
+        reason: 'rate limit state',
       };
     }
     for (const item of systemPrefixes) {
@@ -689,6 +711,23 @@ export class RedisAdminService {
     };
   }
 
+  private matchesListFilter(
+    key: RedisAdminKeySummary,
+    filter?: RedisAdminSystemKind | 'custom' | 'all',
+  ): boolean {
+    if (filter === 'rate_limit' || filter === 'sql_pool_coordination') {
+      return key.systemKind === filter;
+    }
+    if (this.isTransientKey(key)) return false;
+    if (!filter || filter === 'all') return true;
+    if (filter === 'custom') return !key.isSystem && !key.systemKind;
+    return key.systemKind === filter;
+  }
+
+  private isTransientKey(key: RedisAdminKeySummary): boolean {
+    return key.systemKind === 'rate_limit' || key.systemKind === 'sql_pool_coordination';
+  }
+
   private async getUserCacheQuota(): Promise<RedisAdminOverview['userCache']> {
     const usedBytes = Math.max(
       0,
@@ -844,6 +883,8 @@ export class RedisAdminService {
         return 'runtime monitor';
       case 'sql_pool_coordination':
         return 'SQL pool';
+      case 'rate_limit':
+        return 'rate limit';
       case 'system_lock':
         return 'system lock';
     }

--- a/src/modules/admin/services/redis-admin.service.ts
+++ b/src/modules/admin/services/redis-admin.service.ts
@@ -2,6 +2,7 @@ import type { Redis } from 'ioredis';
 import { EnvService } from '../../../shared/services';
 import { UserCacheService } from '../../../engines/cache';
 import { AuthorizationException } from '../../../domain/exceptions';
+import type { RuntimeNamespaceLifecycleService } from '../../../engines/cache/services/runtime-namespace-lifecycle.service';
 import {
   BOOTSTRAP_SCRIPT_EXECUTION_LOCK_KEY,
   PROVISION_LOCK_KEY,
@@ -36,14 +37,18 @@ export class RedisAdminService {
   private readonly userCacheLimitBytes: number;
   private readonly userCacheMaxValueBytes: number;
   private readonly userCacheService: UserCacheService;
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
 
   constructor(deps: {
     redis: Redis;
     envService: EnvService;
     userCacheService: UserCacheService;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
   }) {
     this.redis = deps.redis;
     this.userCacheService = deps.userCacheService;
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
     this.nodeName = deps.envService.get('NODE_NAME') || 'enfyra';
     this.userCacheLimitBytes =
       Number(deps.envService.get('REDIS_USER_CACHE_LIMIT_MB') || 0) *
@@ -78,22 +83,22 @@ export class RedisAdminService {
         .map((key) => this.describeKey(key)),
     );
     const summaries = allSummaries;
-    const currentSummaries = summaries.filter((summary) => summary.namespaceScope === 'current');
+    const currentSummaries = summaries.filter(
+      (summary) => summary.namespaceScope === 'current',
+    );
     const browserSummaries = currentSummaries.filter(
       (summary) => !this.isTransientKey(summary),
     );
 
     for (const summary of currentSummaries) {
       const group = this.groupKey(summary);
-      const current =
-        groups.get(group.name) ??
-        {
-          ...group,
-          count: 0,
-          memoryBytes: 0,
-          system: summary.isSystem,
-          systemKind: summary.systemKind,
-        };
+      const current = groups.get(group.name) ?? {
+        ...group,
+        count: 0,
+        memoryBytes: 0,
+        system: summary.isSystem,
+        systemKind: summary.systemKind,
+      };
       current.count += 1;
       current.memoryBytes += summary.memoryBytes ?? 0;
       current.system = current.system || summary.isSystem;
@@ -146,10 +151,14 @@ export class RedisAdminService {
         count,
       );
       cursor = nextCursor;
-      const summaries = await Promise.all(keys.map((key) => this.describeKey(key)));
+      const summaries = await Promise.all(
+        keys.map((key) => this.describeKey(key)),
+      );
       readable.push(
-        ...summaries.filter((key) =>
-          key.namespaceScope === 'current' && this.matchesListFilter(key, options.filter),
+        ...summaries.filter(
+          (key) =>
+            key.namespaceScope === 'current' &&
+            this.matchesListFilter(key, options.filter),
         ),
       );
     } while (cursor !== '0' && readable.length < count);
@@ -194,7 +203,8 @@ export class RedisAdminService {
     const redisKey = await this.resolveKeyForOperation(input.key);
     this.assertCanModify(redisKey);
     const type = input.type || 'string';
-    const ttlMs = input.ttlSeconds == null ? 0 : Number(input.ttlSeconds) * 1000;
+    const ttlMs =
+      input.ttlSeconds == null ? 0 : Number(input.ttlSeconds) * 1000;
     if (input.ttlSeconds != null) {
       this.assertPositiveTtlSeconds(input.ttlSeconds);
     }
@@ -202,9 +212,18 @@ export class RedisAdminService {
       if (type !== 'string') {
         throw new Error('Redis Admin $cache keys support string values only');
       }
-      await this.userCacheService.set(this.publicKey(redisKey), input.value, ttlMs);
+      await this.userCacheService.set(
+        this.publicKey(redisKey),
+        input.value,
+        ttlMs,
+      );
     } else {
-      await this.writeRawKey(redisKey, type, input.value, input.ttlSeconds ?? null);
+      await this.writeRawKey(
+        redisKey,
+        type,
+        input.value,
+        input.ttlSeconds ?? null,
+      );
     }
     return this.getKey(input.key);
   }
@@ -228,7 +247,7 @@ export class RedisAdminService {
     const redisKey = await this.resolveKeyForOperation(key);
     this.assertCanModify(redisKey);
     if (ttlSeconds == null) {
-      await this.redis.persist(redisKey);
+      await this.redis.expire(redisKey, this.lifecycleTtlSeconds());
     } else {
       this.assertPositiveTtlSeconds(ttlSeconds);
       await this.redis.expire(redisKey, Number(ttlSeconds));
@@ -275,7 +294,10 @@ export class RedisAdminService {
         reason: '$cache user data',
       };
     }
-    if (key.startsWith(`${this.nodeName}:coord:sql:pool:`) || key.startsWith('coord:sql:pool:')) {
+    if (
+      key.startsWith(`${this.nodeName}:coord:sql:pool:`) ||
+      key.startsWith('coord:sql:pool:')
+    ) {
       return {
         isSystem: true,
         modifiable: false,
@@ -380,13 +402,7 @@ export class RedisAdminService {
         return { value, truncated: size > value.length };
       }
       case 'stream': {
-        const items = await this.redis.xrange(
-          key,
-          '-',
-          '+',
-          'COUNT',
-          limit,
-        );
+        const items = await this.redis.xrange(key, '-', '+', 'COUNT', limit);
         const size = await this.redis.xlen(key);
         return {
           value: items.map(([id, fields]) => ({ id, fields })),
@@ -437,7 +453,7 @@ export class RedisAdminService {
       default:
         throw new Error(`Redis Admin cannot write ${type} values`);
     }
-    if (ttlSeconds != null) pipeline.expire(key, ttlSeconds);
+    pipeline.expire(key, ttlSeconds ?? this.lifecycleTtlSeconds());
     await pipeline.exec();
   }
 
@@ -461,7 +477,9 @@ export class RedisAdminService {
     const rows = this.asArray(value);
     return rows.map((item) => {
       if (!item || typeof item !== 'object' || !('value' in item)) {
-        throw new Error('zset value must be an array of { value, score } objects');
+        throw new Error(
+          'zset value must be an array of { value, score } objects',
+        );
       }
       const score = Number(item.score);
       if (!Number.isFinite(score)) {
@@ -485,7 +503,11 @@ export class RedisAdminService {
         Math.min(limit, 100),
       );
       cursor = nextCursor;
-      for (let i = 0; i < rows.length && Object.keys(value).length < limit; i += 2) {
+      for (
+        let i = 0;
+        i < rows.length && Object.keys(value).length < limit;
+        i += 2
+      ) {
         value[rows[i]] = rows[i + 1];
       }
     } while (cursor !== '0' && Object.keys(value).length < limit);
@@ -592,7 +614,9 @@ export class RedisAdminService {
         ? Number(parsed.uptime_in_seconds)
         : undefined,
       usedMemoryHuman: parsed.used_memory_human,
-      usedMemoryBytes: parsed.used_memory ? Number(parsed.used_memory) : undefined,
+      usedMemoryBytes: parsed.used_memory
+        ? Number(parsed.used_memory)
+        : undefined,
       maxMemoryHuman: parsed.maxmemory_human,
       maxMemoryBytes: parsed.maxmemory ? Number(parsed.maxmemory) : undefined,
       totalSystemMemoryHuman: parsed.total_system_memory_human,
@@ -619,7 +643,9 @@ export class RedisAdminService {
     };
   }
 
-  private evaluateHealth(server: RedisAdminOverview['server']): RedisAdminOverview['health'] {
+  private evaluateHealth(
+    server: RedisAdminOverview['server'],
+  ): RedisAdminOverview['health'] {
     const warnings: string[] = [];
     let severity: RedisAdminSeverity = 'ok';
     const used = server.usedMemoryBytes ?? 0;
@@ -628,10 +654,14 @@ export class RedisAdminService {
       const ratio = used / max;
       if (ratio >= REDIS_MEMORY_ERROR_RATIO) {
         severity = 'error';
-        warnings.push(`Redis memory usage is ${this.formatPercent(ratio)} of configured maxmemory.`);
+        warnings.push(
+          `Redis memory usage is ${this.formatPercent(ratio)} of configured maxmemory.`,
+        );
       } else if (ratio >= REDIS_MEMORY_WARNING_RATIO) {
         severity = 'warning';
-        warnings.push(`Redis memory usage is ${this.formatPercent(ratio)} of configured maxmemory.`);
+        warnings.push(
+          `Redis memory usage is ${this.formatPercent(ratio)} of configured maxmemory.`,
+        );
       }
     }
 
@@ -725,13 +755,20 @@ export class RedisAdminService {
   }
 
   private isTransientKey(key: RedisAdminKeySummary): boolean {
-    return key.systemKind === 'rate_limit' || key.systemKind === 'sql_pool_coordination';
+    return (
+      key.systemKind === 'rate_limit' ||
+      key.systemKind === 'sql_pool_coordination'
+    );
   }
 
   private async getUserCacheQuota(): Promise<RedisAdminOverview['userCache']> {
     const usedBytes = Math.max(
       0,
-      Number((await this.redis.get(`${this.nodeName}:user_cache_meta:total_bytes`)) ?? 0),
+      Number(
+        (await this.redis.get(
+          `${this.nodeName}:user_cache_meta:total_bytes`,
+        )) ?? 0,
+      ),
     );
     return {
       usedBytes,
@@ -745,15 +782,16 @@ export class RedisAdminService {
     };
   }
 
-  private effectiveListPattern(
-    patternInput: string | undefined,
-  ): string {
+  private effectiveListPattern(patternInput: string | undefined): string {
     const pattern = patternInput?.trim() || '*';
     if (pattern.startsWith(`${this.nodeName}:`)) return pattern;
     if (this.isSystemPublicKey(pattern) || pattern === '*') {
       return `${this.nodeName}:${pattern}`;
     }
-    if (pattern.startsWith('user_cache:') || pattern.startsWith('user_cache_meta:')) {
+    if (
+      pattern.startsWith('user_cache:') ||
+      pattern.startsWith('user_cache_meta:')
+    ) {
       return `${this.nodeName}:${pattern}`;
     }
     if (!pattern.includes(':')) {
@@ -857,6 +895,14 @@ export class RedisAdminService {
     }
   }
 
+  private lifecycleTtlSeconds(): number {
+    const ttlMs = this.runtimeNamespaceLifecycleService?.getKeyTtlMs();
+    if (!ttlMs || ttlMs <= 0) {
+      throw new Error('Runtime namespace lifecycle TTL is required');
+    }
+    return Math.max(1, Math.ceil(ttlMs / 1000));
+  }
+
   private isReadableKey(key: string): boolean {
     return (
       key.startsWith(`${this.nodeName}:`) ||
@@ -869,7 +915,9 @@ export class RedisAdminService {
     );
   }
 
-  private systemKindLabel(kind: NonNullable<RedisAdminSystemMark['systemKind']>) {
+  private systemKindLabel(
+    kind: NonNullable<RedisAdminSystemMark['systemKind']>,
+  ) {
     switch (kind) {
       case 'runtime_cache':
         return 'runtime cache';
@@ -957,5 +1005,4 @@ export class RedisAdminService {
       throw new Error('key is required');
     }
   }
-
 }

--- a/src/modules/admin/services/redis-admin.service.ts
+++ b/src/modules/admin/services/redis-admin.service.ts
@@ -422,7 +422,7 @@ export class RedisAdminService {
     value: any,
     ttlSeconds: number | null,
   ): Promise<void> {
-    const pipeline = this.redis.pipeline();
+    const pipeline = this.redisTransaction();
     pipeline.del(key);
     switch (type) {
       case 'string':
@@ -901,6 +901,15 @@ export class RedisAdminService {
       throw new Error('Runtime namespace lifecycle TTL is required');
     }
     return Math.max(1, Math.ceil(ttlMs / 1000));
+  }
+
+  private redisTransaction(): ReturnType<Redis['pipeline']> {
+    const redis = this.redis as Redis & {
+      multi?: () => ReturnType<Redis['pipeline']>;
+    };
+    return typeof redis.multi === 'function'
+      ? redis.multi()
+      : this.redis.pipeline();
   }
 
   private isReadableKey(key: string): boolean {

--- a/src/modules/admin/services/runtime-process-metrics.service.ts
+++ b/src/modules/admin/services/runtime-process-metrics.service.ts
@@ -2,10 +2,7 @@ import { monitorEventLoopDelay } from 'perf_hooks';
 import { getHeapStatistics } from 'v8';
 import { Redis } from 'ioredis';
 import { EnvService, InstanceService } from '../../../shared/services';
-import {
-  getEffectiveCpuCount,
-  getEffectiveMemoryBytes,
-} from '@enfyra/kernel';
+import { getEffectiveCpuCount, getEffectiveMemoryBytes } from '@enfyra/kernel';
 import type { RuntimeAverageSample } from '../../../shared/types';
 
 const AVERAGE_FIELDS: Array<keyof RuntimeAverageSample> = [
@@ -141,13 +138,22 @@ export class RuntimeProcessMetricsService {
 
   async pushAverageSample(sample: RuntimeAverageSample) {
     const key = this.averageKey();
-    const pipeline = this.redis.pipeline();
+    const pipeline = this.redisTransaction();
     pipeline.hincrby(key, 'samples', 1);
     for (const field of AVERAGE_FIELDS) {
       pipeline.hincrbyfloat(key, `total:${field}`, sample[field]);
     }
     pipeline.pexpire(key, DEFAULT_AVERAGE_TTL_MS);
     await pipeline.exec();
+  }
+
+  private redisTransaction(): ReturnType<Redis['pipeline']> {
+    const redis = this.redis as Redis & {
+      multi?: () => ReturnType<Redis['pipeline']>;
+    };
+    return typeof redis.multi === 'function'
+      ? redis.multi()
+      : this.redis.pipeline();
   }
 
   async getAverages() {

--- a/src/modules/admin/types/redis-admin.types.ts
+++ b/src/modules/admin/types/redis-admin.types.ts
@@ -22,6 +22,7 @@ export type RedisAdminSystemKind =
   | 'socket_io'
   | 'runtime_monitor'
   | 'sql_pool_coordination'
+  | 'rate_limit'
   | 'system_lock';
 
 export type RedisAdminNamespaceScope = 'current' | 'global';

--- a/src/modules/flow/queues/flow-execution-queue.service.ts
+++ b/src/modules/flow/queues/flow-execution-queue.service.ts
@@ -696,6 +696,10 @@ export class FlowExecutionQueueService {
         sourceFlowId: flow.id,
         sourceFlowName: flow.name,
         sourceStepKey,
+      }, {
+        attempts: 1,
+        removeOnComplete: { count: 200, age: 3600 * 24 },
+        removeOnFail: { count: 500, age: 3600 * 24 * 7 },
       });
       return {
         triggered: true,
@@ -948,6 +952,10 @@ export class FlowExecutionQueueService {
         sourceFlowId: (ctx as any).$flow?.$meta?.flowId,
         sourceFlowName: (ctx as any).$flow?.$meta?.flowName,
         sourceStepKey: step.key,
+      }, {
+        attempts: 1,
+        removeOnComplete: { count: 200, age: 3600 * 24 },
+        removeOnFail: { count: 500, age: 3600 * 24 * 7 },
       });
       return {
         triggered: true,

--- a/src/modules/flow/queues/flow-execution-queue.service.ts
+++ b/src/modules/flow/queues/flow-execution-queue.service.ts
@@ -32,6 +32,7 @@ import {
 import { SYSTEM_QUEUES } from '../../../shared/utils/constant';
 import { CACHE_IDENTIFIERS } from '../../../shared/utils/cache-events.constants';
 import type { RuntimeRegistryService } from '../../../engines/cache/services/runtime-registry.service';
+import type { RuntimeNamespaceLifecycleService } from '../../../engines/cache/services/runtime-namespace-lifecycle.service';
 
 export type { FlowJobData } from '../../../shared/types/flow.types';
 
@@ -69,6 +70,7 @@ export class FlowExecutionQueueService {
   private readonly envService: EnvService;
   private readonly isolatedExecutorService: IsolatedExecutorService;
   private readonly runtimeMetricsCollectorService?: RuntimeMetricsCollectorService;
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
   private readonly flowQueue: Queue;
   private readonly traceFile?: string;
   private readonly flowWorkerEventLoopDelay = monitorEventLoopDelay({
@@ -90,6 +92,7 @@ export class FlowExecutionQueueService {
     envService: EnvService;
     isolatedExecutorService: IsolatedExecutorService;
     runtimeMetricsCollectorService?: RuntimeMetricsCollectorService;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
     flowQueue: Queue;
   }) {
     this.executorEngineService = deps.executorEngineService;
@@ -101,6 +104,8 @@ export class FlowExecutionQueueService {
     this.envService = deps.envService;
     this.isolatedExecutorService = deps.isolatedExecutorService;
     this.runtimeMetricsCollectorService = deps.runtimeMetricsCollectorService;
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
     this.flowQueue = deps.flowQueue;
     const traceFile = this.envService.get('FLOW_WORKER_TRACE_FILE');
     this.traceFile =
@@ -687,20 +692,25 @@ export class FlowExecutionQueueService {
           : this.getFlowByName(String(flowIdOrName));
       if (!targetFlow) throw new Error(`Flow "${flowIdOrName}" not found`);
       const sourceStepKey = (ctx as any).$flow?.$meta?.currentStep;
-      await this.flowQueue.add(`flow:${targetFlow.name}`, {
-        flowId: targetFlow.id,
-        flowName: targetFlow.name,
-        payload: triggerPayload,
-        depth: depth + 1,
-        visitedFlowIds,
-        sourceFlowId: flow.id,
-        sourceFlowName: flow.name,
-        sourceStepKey,
-      }, {
-        attempts: 1,
-        removeOnComplete: { count: 200, age: 3600 * 24 },
-        removeOnFail: { count: 500, age: 3600 * 24 * 7 },
-      });
+      await this.flowQueue.add(
+        `flow:${targetFlow.name}`,
+        {
+          flowId: targetFlow.id,
+          flowName: targetFlow.name,
+          payload: triggerPayload,
+          depth: depth + 1,
+          visitedFlowIds,
+          sourceFlowId: flow.id,
+          sourceFlowName: flow.name,
+          sourceStepKey,
+        },
+        {
+          attempts: 1,
+          removeOnComplete: { count: 200, age: 3600 * 24 },
+          removeOnFail: { count: 500, age: 3600 * 24 * 7 },
+        },
+      );
+      await this.touchFlowQueueKeys();
       return {
         triggered: true,
         flowId: targetFlow.id,
@@ -943,20 +953,25 @@ export class FlowExecutionQueueService {
       const childPayload =
         (config as any).payload || (ctx as any).$flow?.$last || {};
       const currentDepth = (ctx as any).$flow?.$meta?.depth || 0;
-      await this.flowQueue.add(`flow:${targetFlow.name}`, {
-        flowId: targetFlow.id,
-        flowName: targetFlow.name,
-        payload: childPayload,
-        depth: currentDepth + 1,
-        visitedFlowIds,
-        sourceFlowId: (ctx as any).$flow?.$meta?.flowId,
-        sourceFlowName: (ctx as any).$flow?.$meta?.flowName,
-        sourceStepKey: step.key,
-      }, {
-        attempts: 1,
-        removeOnComplete: { count: 200, age: 3600 * 24 },
-        removeOnFail: { count: 500, age: 3600 * 24 * 7 },
-      });
+      await this.flowQueue.add(
+        `flow:${targetFlow.name}`,
+        {
+          flowId: targetFlow.id,
+          flowName: targetFlow.name,
+          payload: childPayload,
+          depth: currentDepth + 1,
+          visitedFlowIds,
+          sourceFlowId: (ctx as any).$flow?.$meta?.flowId,
+          sourceFlowName: (ctx as any).$flow?.$meta?.flowName,
+          sourceStepKey: step.key,
+        },
+        {
+          attempts: 1,
+          removeOnComplete: { count: 200, age: 3600 * 24 },
+          removeOnFail: { count: 500, age: 3600 * 24 * 7 },
+        },
+      );
+      await this.touchFlowQueueKeys();
       return {
         triggered: true,
         flowId: targetFlow.id,
@@ -971,6 +986,12 @@ export class FlowExecutionQueueService {
       ctx,
       executorEngineService: this.executorEngineService,
     });
+  }
+
+  private async touchFlowQueueKeys(): Promise<void> {
+    await this.runtimeNamespaceLifecycleService?.renewSystemQueueKeys(
+      SYSTEM_QUEUES.FLOW_EXECUTION,
+    );
   }
 
   private getFlows(): FlowDefinition[] {

--- a/src/modules/flow/services/flow-scheduler.service.ts
+++ b/src/modules/flow/services/flow-scheduler.service.ts
@@ -3,7 +3,9 @@ import { parseExpression } from 'cron-parser';
 import { Queue } from 'bullmq';
 import { getErrorMessage } from '../../../shared/utils/error.util';
 import { CACHE_IDENTIFIERS } from '../../../shared/utils/cache-events.constants';
+import { SYSTEM_QUEUES } from '../../../shared/utils/constant';
 import type { RuntimeRegistryService } from '../../../engines/cache/services/runtime-registry.service';
+import type { RuntimeNamespaceLifecycleService } from '../../../engines/cache/services/runtime-namespace-lifecycle.service';
 
 interface ScheduledFlow {
   id: string | number;
@@ -38,14 +40,18 @@ export class FlowSchedulerService {
   };
   private readonly flowQueue: Queue;
   private readonly runtimeRegistryService: RuntimeRegistryService;
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
 
   constructor(deps: {
     flowQueue: Queue;
     runtimeRegistryService: RuntimeRegistryService;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
     eventEmitter?: any;
   }) {
     this.flowQueue = deps.flowQueue;
     this.runtimeRegistryService = deps.runtimeRegistryService;
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
   }
 
   async init(): Promise<void> {
@@ -142,6 +148,9 @@ export class FlowSchedulerService {
       if (registered > 0) {
         this.logger.log(`Registered ${registered} scheduled flows`);
       }
+      await this.runtimeNamespaceLifecycleService?.renewSystemQueueKeys(
+        SYSTEM_QUEUES.FLOW_EXECUTION,
+      );
 
       this.lastReconcileState = {
         status: 'ok',

--- a/src/modules/flow/services/flow.service.ts
+++ b/src/modules/flow/services/flow.service.ts
@@ -11,7 +11,9 @@ import {
 import { SocketEmitCapture } from '../../websocket';
 import { DynamicContextFactory } from '../../../shared/services';
 import { CACHE_IDENTIFIERS } from '../../../shared/utils/cache-events.constants';
+import { SYSTEM_QUEUES } from '../../../shared/utils/constant';
 import type { RuntimeRegistryService } from '../../../engines/cache/services/runtime-registry.service';
+import type { RuntimeNamespaceLifecycleService } from '../../../engines/cache/services/runtime-namespace-lifecycle.service';
 import type {
   FlowDefinition,
   FlowStep,
@@ -38,6 +40,7 @@ export class FlowService {
   private readonly executorEngineService: ExecutorEngineService;
   private readonly repoRegistryService: RepoRegistryService;
   private readonly dynamicContextFactory: DynamicContextFactory;
+  private readonly runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
 
   constructor(deps: {
     flowQueue: Queue;
@@ -45,12 +48,15 @@ export class FlowService {
     executorEngineService: ExecutorEngineService;
     repoRegistryService: RepoRegistryService;
     dynamicContextFactory: DynamicContextFactory;
+    runtimeNamespaceLifecycleService?: RuntimeNamespaceLifecycleService;
   }) {
     this.flowQueue = deps.flowQueue;
     this.runtimeRegistryService = deps.runtimeRegistryService;
     this.executorEngineService = deps.executorEngineService;
     this.repoRegistryService = deps.repoRegistryService;
     this.dynamicContextFactory = deps.dynamicContextFactory;
+    this.runtimeNamespaceLifecycleService =
+      deps.runtimeNamespaceLifecycleService;
   }
 
   async trigger(
@@ -88,6 +94,9 @@ export class FlowService {
       removeOnComplete: { count: 200, age: 3600 * 24 },
       removeOnFail: { count: 500, age: 3600 * 24 * 7 },
     });
+    await this.runtimeNamespaceLifecycleService?.renewSystemQueueKeys(
+      SYSTEM_QUEUES.FLOW_EXECUTION,
+    );
 
     this.logger.debug(`Flow "${flow.name}" triggered, job ${job.id}`);
     return { jobId: String(job.id), flowId: flow.id };

--- a/src/modules/websocket/gateway/dynamic-websocket.gateway.ts
+++ b/src/modules/websocket/gateway/dynamic-websocket.gateway.ts
@@ -577,6 +577,7 @@ export class DynamicWebSocketGateway {
           cursor: payload?.cursor,
           pattern: payload?.pattern,
           count: payload?.count,
+          filter: payload?.filter,
         }),
       );
     });

--- a/src/shared/services/cluster-telemetry.service.ts
+++ b/src/shared/services/cluster-telemetry.service.ts
@@ -40,7 +40,7 @@ export class ClusterTelemetryService {
     const sampledAt = options.sampledAt ?? new Date().toISOString();
     const now = Date.now();
     const instancesKey = this.instancesKey(namespace);
-    const pipeline = this.redis.pipeline();
+    const pipeline = this.redisTransaction();
     pipeline.set(
       this.payloadKey(namespace, instanceId),
       JSON.stringify({ instanceId, sampledAt, payload }),
@@ -94,5 +94,14 @@ export class ClusterTelemetryService {
       .del(this.payloadKey(namespace, instanceId))
       .zrem(this.instancesKey(namespace), instanceId)
       .exec();
+  }
+
+  private redisTransaction(): ReturnType<Redis['pipeline']> {
+    const redis = this.redis as Redis & {
+      multi?: () => ReturnType<Redis['pipeline']>;
+    };
+    return typeof redis.multi === 'function'
+      ? redis.multi()
+      : this.redis.pipeline();
   }
 }

--- a/src/shared/services/runtime-metrics-collector.service.ts
+++ b/src/shared/services/runtime-metrics-collector.service.ts
@@ -27,7 +27,10 @@ function pushLatency(target: number[], value: number) {
 function percentile(values: number[], p: number) {
   if (values.length === 0) return 0;
   const sorted = [...values].sort((a, b) => a - b);
-  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((p / 100) * sorted.length) - 1,
+  );
   return sorted[Math.max(0, index)];
 }
 
@@ -63,18 +66,16 @@ class RuntimeMetricsRedisStore {
       const raw = await this.redis.hget(key, field);
       const metric = raw ? (JSON.parse(raw) as T) : create();
       update(metric);
-      await this.redis
-        .pipeline()
-        .hset(key, field, JSON.stringify(metric))
-        .pexpire(key, LIVE_METRIC_TTL_MS)
-        .exec();
+      const pipeline = this.redisTransaction();
+      pipeline.hset(key, field, JSON.stringify(metric));
+      pipeline.pexpire(key, LIVE_METRIC_TTL_MS);
+      await pipeline.exec();
     });
   }
 
   pushCacheReload(record: RuntimeCacheReloadMetric): void {
     this.enqueue(() =>
-      this.redis
-        .pipeline()
+      this.redisTransaction()
         .lpush(this.keys.cacheReloads, JSON.stringify(record))
         .ltrim(this.keys.cacheReloads, 0, MAX_RECENT - 1)
         .pexpire(this.keys.cacheReloads, CACHE_RELOAD_TTL_MS)
@@ -126,8 +127,19 @@ class RuntimeMetricsRedisStore {
     this.writeChain = this.writeChain.then(operation).catch(() => {});
   }
 
+  private redisTransaction(): ReturnType<Redis['pipeline']> {
+    const redis = this.redis as Redis & {
+      multi?: () => ReturnType<Redis['pipeline']>;
+    };
+    return typeof redis.multi === 'function'
+      ? redis.multi()
+      : this.redis.pipeline();
+  }
+
   private async readHash<T>(bucket: RuntimeMetricsHashBucket): Promise<T[]> {
-    return this.parseRows(Object.values(await this.redis.hgetall(this.keys[bucket])));
+    return this.parseRows(
+      Object.values(await this.redis.hgetall(this.keys[bucket])),
+    );
   }
 
   private parseRows<T>(values: string[]): T[] {
@@ -206,19 +218,17 @@ export class RuntimeMetricsCollectorService {
     }
 
     const key = `${input.method}:${input.route}`;
-    const current =
-      this.requests.get(key) ??
-      {
-        method: input.method,
-        route: input.route,
-        count: 0,
-        status2xx: 0,
-        status3xx: 0,
-        status4xx: 0,
-        status5xx: 0,
-        totalMs: 0,
-        latencies: [],
-      };
+    const current = this.requests.get(key) ?? {
+      method: input.method,
+      route: input.route,
+      count: 0,
+      status2xx: 0,
+      status3xx: 0,
+      status4xx: 0,
+      status5xx: 0,
+      totalMs: 0,
+      latencies: [],
+    };
     this.applyRequestMetric(current, input);
     this.requests.set(key, current);
   }
@@ -254,19 +264,17 @@ export class RuntimeMetricsCollectorService {
     }
 
     const key = `${context}:${input.op}:${table}`;
-    const current =
-      this.queries.get(key) ??
-      {
-        context,
-        op: input.op,
-        table,
-        count: 0,
-        errors: 0,
-        poolAcquireTimeouts: 0,
-        slow: 0,
-        totalMs: 0,
-        latencies: [],
-      };
+    const current = this.queries.get(key) ?? {
+      context,
+      op: input.op,
+      table,
+      count: 0,
+      errors: 0,
+      poolAcquireTimeouts: 0,
+      slow: 0,
+      totalMs: 0,
+      latencies: [],
+    };
     this.applyQueryMetric(current, input);
     this.queries.set(key, current);
   }
@@ -452,18 +460,27 @@ export class RuntimeMetricsCollectorService {
         running: item.running,
         completed: item.completed,
         failed: item.failed,
-        avgMs: item.completed + item.failed > 0 ? item.totalMs / (item.completed + item.failed) : 0,
+        avgMs:
+          item.completed + item.failed > 0
+            ? item.totalMs / (item.completed + item.failed)
+            : 0,
         p95Ms: percentile(item.latencies, 95),
         failedSteps: Object.entries(item.failedSteps)
           .map(([step, count]) => ({ step, count }))
           .sort((a, b) => b.count - a.count)
           .slice(0, 5),
         slowSteps: Object.entries(item.stepLatencies)
-          .map(([step, latencies]) => ({ step, p95Ms: percentile(latencies, 95) }))
+          .map(([step, latencies]) => ({
+            step,
+            p95Ms: percentile(latencies, 95),
+          }))
           .sort((a, b) => b.p95Ms - a.p95Ms)
           .slice(0, 5),
       }))
-      .sort((a, b) => b.running - a.running || b.failed - a.failed || b.p95Ms - a.p95Ms)
+      .sort(
+        (a, b) =>
+          b.running - a.running || b.failed - a.failed || b.p95Ms - a.p95Ms,
+      )
       .slice(0, 20);
 
     return {
@@ -500,8 +517,7 @@ export class RuntimeMetricsCollectorService {
   ): RuntimeFlowMetric {
     const key = String(flowId);
     const current =
-      this.flows.get(key) ??
-      this.createFlowMetric(flowId, flowName);
+      this.flows.get(key) ?? this.createFlowMetric(flowId, flowName);
     this.flows.set(key, current);
     return current;
   }
@@ -592,5 +608,4 @@ export class RuntimeMetricsCollectorService {
         (metric.failedSteps[input.stepKey] ?? 0) + 1;
     }
   }
-
 }

--- a/test/admin/redis-admin.service.spec.ts
+++ b/test/admin/redis-admin.service.spec.ts
@@ -417,6 +417,24 @@ describe('RedisAdminService', () => {
     ).toBe(1800);
   });
 
+  it.each([
+    ['hash', { field: 'value' }],
+    ['list', ['a', 'b']],
+    ['set', ['a', 'b']],
+    ['zset', [{ value: 'a', score: 1 }]],
+  ] as const)('uses lifecycle ttl for raw %s writes', async (type, value) => {
+    const { redis, service } = makeService();
+    redis.setSync(`app-a:custom:${type}`, 'old');
+
+    await service.setKey({
+      key: `custom:${type}`,
+      type,
+      value,
+    });
+
+    expect(redis.values.get(`app-a:custom:${type}`)?.ttl).toBe(1800);
+  });
+
   it('searches editable keys through the $cache user_cache namespace', async () => {
     const { redis, service } = makeService();
     redis.setSync('app-a:user_cache:feature', 'enabled');

--- a/test/admin/redis-admin.service.spec.ts
+++ b/test/admin/redis-admin.service.spec.ts
@@ -97,13 +97,13 @@ class FakeRedis {
     const matchIndex = args.findIndex((item) => item === 'MATCH');
     const pattern = matchIndex >= 0 ? String(args[matchIndex + 1]) : '*';
     const regex = new RegExp(
-      `^${pattern
-        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-        .replace(/\*/g, '.*')}$`,
+      `^${pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')}$`,
     );
     return [
       '0',
-      cursor === '0' ? [...this.values.keys()].filter((key) => regex.test(key)) : [],
+      cursor === '0'
+        ? [...this.values.keys()].filter((key) => regex.test(key))
+        : [],
     ];
   }
 
@@ -155,7 +155,10 @@ class FakeRedis {
 
   async hscan(key: string) {
     const value = this.values.get(key)?.value ?? {};
-    return ['0', Object.entries(value).flatMap(([field, item]) => [field, item])];
+    return [
+      '0',
+      Object.entries(value).flatMap(([field, item]) => [field, item]),
+    ];
   }
 
   async lrange(key: string, start: number, end: number) {
@@ -194,12 +197,6 @@ class FakeRedis {
   async expire(key: string, ttl: number) {
     this.expireSync(key, ttl);
     return 1;
-  }
-
-  async persist(key: string) {
-    const value = this.values.get(key);
-    if (value) value.ttl = -1;
-    return value ? 1 : 0;
   }
 
   delSync(key: string) {
@@ -242,12 +239,13 @@ class FakeRedis {
 }
 
 function makeService(redis = new FakeRedis()) {
+  const lifecycleTtlMs = 30 * 60 * 1000;
   const userCacheService = {
     async set(key: string, value: any, ttlMs: number) {
       redis.values.set(`app-a:user_cache:${key}`, {
         type: 'string',
         value: typeof value === 'string' ? value : JSON.stringify(value),
-        ttl: ttlMs > 0 ? ttlMs / 1000 : -1,
+        ttl: ttlMs > 0 ? ttlMs / 1000 : lifecycleTtlMs / 1000,
       });
     },
     async deleteKey(key: string) {
@@ -262,6 +260,9 @@ function makeService(redis = new FakeRedis()) {
         get: (key: string) => (key === 'NODE_NAME' ? 'app-a' : 0),
       } as any,
       userCacheService: userCacheService as any,
+      runtimeNamespaceLifecycleService: {
+        getKeyTtlMs: () => lifecycleTtlMs,
+      } as any,
     }),
   };
 }
@@ -391,6 +392,31 @@ describe('RedisAdminService', () => {
     expect(redis.values.has('app-a:user_cache:user:feature-flag')).toBe(true);
   });
 
+  it('uses lifecycle ttl instead of persisting custom keys', async () => {
+    const { redis, service } = makeService();
+
+    const detail = await service.setKey({
+      key: 'user:lifecycle-default',
+      type: 'string',
+      value: 'enabled',
+    });
+
+    expect(detail.ttlSeconds).toBe(1800);
+    expect(
+      redis.values.get('app-a:user_cache:user:lifecycle-default')?.ttl,
+    ).toBe(1800);
+
+    await service.expireKey('user:lifecycle-default', 120);
+    expect(
+      redis.values.get('app-a:user_cache:user:lifecycle-default')?.ttl,
+    ).toBe(120);
+
+    await service.expireKey('user:lifecycle-default', null);
+    expect(
+      redis.values.get('app-a:user_cache:user:lifecycle-default')?.ttl,
+    ).toBe(1800);
+  });
+
   it('searches editable keys through the $cache user_cache namespace', async () => {
     const { redis, service } = makeService();
     redis.setSync('app-a:user_cache:feature', 'enabled');
@@ -412,14 +438,22 @@ describe('RedisAdminService', () => {
     const { redis, service } = makeService();
     redis.setSync('app-a:user:0c94ba93-5440-4038-80f6-919e9787aabf', 'legacy');
 
-    const detail = await service.getKey('user:0c94ba93-5440-4038-80f6-919e9787aabf');
+    const detail = await service.getKey(
+      'user:0c94ba93-5440-4038-80f6-919e9787aabf',
+    );
     expect(detail.value).toBe('legacy');
 
     await expect(
       service.deleteKey('user:0c94ba93-5440-4038-80f6-919e9787aabf'),
     ).resolves.toEqual({ deleted: 1 });
-    expect(redis.values.has('app-a:user:0c94ba93-5440-4038-80f6-919e9787aabf')).toBe(false);
-    expect(redis.values.has('app-a:user_cache:user:0c94ba93-5440-4038-80f6-919e9787aabf')).toBe(false);
+    expect(
+      redis.values.has('app-a:user:0c94ba93-5440-4038-80f6-919e9787aabf'),
+    ).toBe(false);
+    expect(
+      redis.values.has(
+        'app-a:user_cache:user:0c94ba93-5440-4038-80f6-919e9787aabf',
+      ),
+    ).toBe(false);
   });
 
   it('marks user cache quota trackers as editable user cache, not system', async () => {
@@ -465,7 +499,9 @@ describe('RedisAdminService', () => {
         reason: 'runtime cache snapshot',
       }),
     );
-    await expect(service.deleteKey('app-a:runtime_cache:metadata')).rejects.toMatchObject({
+    await expect(
+      service.deleteKey('app-a:runtime_cache:metadata'),
+    ).rejects.toMatchObject({
       statusCode: 403,
       errorCode: 'AUTHORIZATION_ERROR',
     });
@@ -496,7 +532,9 @@ describe('RedisAdminService', () => {
     const current = await service.listKeys({});
     const overview = await service.getOverview();
 
-    expect(current.keys.map((item) => item.key)).toEqual(['runtime_cache:metadata']);
+    expect(current.keys.map((item) => item.key)).toEqual([
+      'runtime_cache:metadata',
+    ]);
     expect(overview.groups[0]).toEqual(
       expect.objectContaining({
         name: 'runtime cache',
@@ -505,7 +543,9 @@ describe('RedisAdminService', () => {
       }),
     );
     expect(current.keys).not.toEqual(
-      expect.arrayContaining([expect.objectContaining({ namespace: 'enfyra_bench_1' })]),
+      expect.arrayContaining([
+        expect.objectContaining({ namespace: 'enfyra_bench_1' }),
+      ]),
     );
   });
 
@@ -519,7 +559,9 @@ describe('RedisAdminService', () => {
     });
     const detail = await service.getKey('runtime_cache:metadata');
 
-    expect(result.keys.map((item) => item.key)).toEqual(['runtime_cache:metadata']);
+    expect(result.keys.map((item) => item.key)).toEqual([
+      'runtime_cache:metadata',
+    ]);
     expect(detail).toEqual(
       expect.objectContaining({
         key: 'runtime_cache:metadata',

--- a/test/cache/cache.service.spec.ts
+++ b/test/cache/cache.service.spec.ts
@@ -25,4 +25,29 @@ describe('CacheService', () => {
       7000,
     );
   });
+
+  it('acquires zero-ttl locks with namespace lifecycle ttl when available', async () => {
+    const redis = {
+      set: vi.fn(async () => 'OK'),
+    };
+    const service = new CacheService({
+      redis: redis as any,
+      envService: {
+        get: (key: string) => (key === 'NODE_NAME' ? 'app-a' : null),
+      } as any,
+      runtimeNamespaceLifecycleService: {
+        getKeyTtlMs: () => 7000,
+      } as any,
+    });
+
+    await service.acquire('lock:boot', 'token', 0);
+
+    expect(redis.set).toHaveBeenCalledWith(
+      'app-a:lock:boot',
+      'token',
+      'PX',
+      7000,
+      'NX',
+    );
+  });
 });

--- a/test/cache/cache.service.spec.ts
+++ b/test/cache/cache.service.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CacheService } from '../../src/engines/cache/services/cache.service';
+
+describe('CacheService', () => {
+  it('stores zero-ttl values with namespace lifecycle ttl when available', async () => {
+    const redis = {
+      set: vi.fn(async () => 'OK'),
+    };
+    const service = new CacheService({
+      redis: redis as any,
+      envService: {
+        get: (key: string) => (key === 'NODE_NAME' ? 'app-a' : null),
+      } as any,
+      runtimeNamespaceLifecycleService: {
+        getKeyTtlMs: () => 7000,
+      } as any,
+    });
+
+    await service.set('auth:oauth-exchange:pending:code', { ok: true }, 0);
+
+    expect(redis.set).toHaveBeenCalledWith(
+      'app-a:auth:oauth-exchange:pending:code',
+      JSON.stringify({ ok: true }),
+      'PX',
+      7000,
+    );
+  });
+});

--- a/test/cache/rate-limit.service.spec.ts
+++ b/test/cache/rate-limit.service.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RateLimitService } from '../../src/engines/cache';
+
+describe('RateLimitService', () => {
+  it('keeps blocked rate-limit keys on a Redis TTL', async () => {
+    const redis = {
+      eval: vi.fn(async () => [0, 0, Date.now() + 1000, 1]),
+    };
+    const service = new RateLimitService({
+      redis: redis as any,
+      envService: { get: () => 'app-a' } as any,
+    });
+
+    await service.check('route:/orders', { maxRequests: 1, perSeconds: 60 });
+
+    const script = redis.eval.mock.calls[0]?.[0] as string;
+    expect(script).toContain(
+      "else\n      redis.call('PEXPIRE', key, window * 1000)",
+    );
+  });
+
+  it('repairs lifecycle TTL when reading rate-limit status', async () => {
+    const operations: Array<{ name: string; args: any[] }> = [];
+    const pipeline = {
+      zremrangebyscore: vi.fn((...args: any[]) => {
+        operations.push({ name: 'zremrangebyscore', args });
+        return pipeline;
+      }),
+      zcard: vi.fn((...args: any[]) => {
+        operations.push({ name: 'zcard', args });
+        return pipeline;
+      }),
+      zrange: vi.fn((...args: any[]) => {
+        operations.push({ name: 'zrange', args });
+        return pipeline;
+      }),
+      pexpire: vi.fn((...args: any[]) => {
+        operations.push({ name: 'pexpire', args });
+        return pipeline;
+      }),
+      exec: vi.fn(async () => [
+        [null, 0],
+        [null, 1],
+        [null, ['member', String(Date.now())]],
+        [null, 1],
+      ]),
+    };
+    const service = new RateLimitService({
+      redis: { pipeline: () => pipeline } as any,
+      envService: { get: () => 'app-a' } as any,
+    });
+
+    await service.status('route:/orders', {
+      maxRequests: 5,
+      perSeconds: 60,
+    });
+
+    expect(pipeline.pexpire).toHaveBeenCalledWith(
+      'app-a:rl:route:/orders',
+      60000,
+    );
+    expect(operations.map((item) => item.name)).toEqual([
+      'zremrangebyscore',
+      'zcard',
+      'zrange',
+      'pexpire',
+    ]);
+  });
+});

--- a/test/cache/redis-runtime-cache-store.spec.ts
+++ b/test/cache/redis-runtime-cache-store.spec.ts
@@ -9,6 +9,7 @@ import { CACHE_IDENTIFIERS } from '../../src/shared/utils/cache-events.constants
 
 class MemoryRedis {
   data = new Map<string, string | Buffer>();
+  expiries = new Map<string, number>();
 
   async get(key: string) {
     const value = this.data.get(key);
@@ -22,9 +23,13 @@ class MemoryRedis {
     return Buffer.isBuffer(value) ? value : Buffer.from(value);
   }
 
-  async set(key: string, value: string | Buffer, ...args: string[]) {
+  async set(key: string, value: string | Buffer, ...args: any[]) {
     if (args.includes('NX') && this.data.has(key)) return null;
     this.data.set(key, value);
+    const pxIndex = args.indexOf('PX');
+    if (pxIndex >= 0 && typeof args[pxIndex + 1] === 'number') {
+      this.expiries.set(key, args[pxIndex + 1]);
+    }
     return 'OK';
   }
 
@@ -61,6 +66,25 @@ function createStore(redis = new MemoryRedis()) {
         if (key === 'NODE_NAME') return 'shared-node';
         if (key === 'REDIS_RUNTIME_CACHE') return true;
         return undefined;
+      },
+    } as any,
+  });
+}
+
+function createStoreWithLifecycle(redis = new MemoryRedis()) {
+  return new RedisRuntimeCacheStore({
+    redis: redis as any,
+    envService: {
+      get: (key: string) => {
+        if (key === 'NODE_NAME') return 'shared-node';
+        if (key === 'REDIS_RUNTIME_CACHE') return true;
+        return undefined;
+      },
+    } as any,
+    runtimeNamespaceLifecycleService: {
+      getKeyTtlMs: () => 5000,
+      touchKey: async (key: string) => {
+        redis.expiries.set(key, 5000);
       },
     } as any,
   });
@@ -113,6 +137,15 @@ describe('Redis runtime cache mode', () => {
     expect(snapshot?.data.get('alpha')).toEqual(new Set(['one', 'two']));
     expect(() => cache.getRawCache()).toThrow(/Redis-backed/);
     expect(redis.data.has('shared-node:runtime_cache:setting')).toBe(true);
+  });
+
+  it('stores runtime snapshots with namespace lifecycle TTL when available', async () => {
+    const redis = new MemoryRedis();
+    const store = createStoreWithLifecycle(redis);
+
+    await store.setSnapshot(CACHE_IDENTIFIERS.SETTING, { ok: true });
+
+    expect(redis.expiries.get('shared-node:runtime_cache:setting')).toBe(5000);
   });
 
   it('round-trips structured cache values through JSON snapshots', async () => {

--- a/test/cache/redis-runtime-cache-store.spec.ts
+++ b/test/cache/redis-runtime-cache-store.spec.ts
@@ -43,10 +43,7 @@ class MemoryRedis {
 
   async scan(_cursor: string, _match: string, pattern: string) {
     const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;
-    return [
-      '0',
-      [...this.data.keys()].filter((key) => key.startsWith(prefix)),
-    ];
+    return ['0', [...this.data.keys()].filter((key) => key.startsWith(prefix))];
   }
 
   async del(...keys: string[]) {
@@ -68,19 +65,6 @@ function createStore(redis = new MemoryRedis()) {
         return undefined;
       },
     } as any,
-  });
-}
-
-function createStoreWithLifecycle(redis = new MemoryRedis()) {
-  return new RedisRuntimeCacheStore({
-    redis: redis as any,
-    envService: {
-      get: (key: string) => {
-        if (key === 'NODE_NAME') return 'shared-node';
-        if (key === 'REDIS_RUNTIME_CACHE') return true;
-        return undefined;
-      },
-    } as any,
     runtimeNamespaceLifecycleService: {
       getKeyTtlMs: () => 5000,
       touchKey: async (key: string) => {
@@ -88,6 +72,10 @@ function createStoreWithLifecycle(redis = new MemoryRedis()) {
       },
     } as any,
   });
+}
+
+function createStoreWithLifecycle(redis = new MemoryRedis()) {
+  return createStore(redis);
 }
 
 class SharedTestCache extends BaseCacheService<Map<string, Set<string>>> {

--- a/test/cache/redis-runtime-cache-store.spec.ts
+++ b/test/cache/redis-runtime-cache-store.spec.ts
@@ -136,6 +136,34 @@ describe('Redis runtime cache mode', () => {
     expect(redis.expiries.get('shared-node:runtime_cache:setting')).toBe(5000);
   });
 
+  it('renews runtime snapshot lifecycle TTL when reading a shared snapshot', async () => {
+    const redis = new MemoryRedis();
+    const store = createStoreWithLifecycle(redis);
+
+    await store.setSnapshot(CACHE_IDENTIFIERS.SETTING, { ok: true });
+    redis.expiries.set('shared-node:runtime_cache:setting', 100);
+    await store.getSnapshot(CACHE_IDENTIFIERS.SETTING);
+
+    expect(redis.expiries.get('shared-node:runtime_cache:setting')).toBe(5000);
+  });
+
+  it('stores and renews runtime aux keys with namespace lifecycle TTL', async () => {
+    const redis = new MemoryRedis();
+    const store = createStoreWithLifecycle(redis);
+
+    await store.setAux(CACHE_IDENTIFIERS.ROUTE, 'match-index', [{ id: 1 }]);
+    expect(
+      redis.expiries.get('shared-node:runtime_cache:route:aux:match_index'),
+    ).toBe(5000);
+
+    redis.expiries.set('shared-node:runtime_cache:route:aux:match_index', 100);
+    await store.getAux(CACHE_IDENTIFIERS.ROUTE, 'match-index');
+
+    expect(
+      redis.expiries.get('shared-node:runtime_cache:route:aux:match_index'),
+    ).toBe(5000);
+  });
+
   it('round-trips structured cache values through JSON snapshots', async () => {
     const store = createStore();
     const timestamp = new Date('2026-04-29T00:00:00.000Z');

--- a/test/cache/runtime-namespace-lifecycle.service.spec.ts
+++ b/test/cache/runtime-namespace-lifecycle.service.spec.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import { RuntimeNamespaceLifecycleService } from '../../src/engines/cache';
+
+class FakePipeline {
+  private readonly ops: Array<() => void> = [];
+
+  constructor(private readonly redis: FakeRedis) {}
+
+  set(key: string, value: string, mode?: string, ttlMs?: number) {
+    this.ops.push(() => this.redis.setSync(key, value, mode, ttlMs));
+    return this;
+  }
+
+  zadd(key: string, score: number, member: string) {
+    this.ops.push(() => this.redis.zaddSync(key, score, member));
+    return this;
+  }
+
+  hset(key: string, value: Record<string, string>) {
+    this.ops.push(() => this.redis.hsetSync(key, value));
+    return this;
+  }
+
+  pexpire(key: string, ttlMs: number) {
+    this.ops.push(() => this.redis.pexpireSync(key, ttlMs));
+    return this;
+  }
+
+  async exec() {
+    for (const op of this.ops) op();
+    return [];
+  }
+}
+
+class FakeRedis {
+  values = new Map<string, string>();
+  hashes = new Map<string, Map<string, string>>();
+  zsets = new Map<string, Map<string, number>>();
+  expiries = new Map<string, number>();
+
+  pipeline() {
+    return new FakePipeline(this);
+  }
+
+  async set(key: string, value: string, mode?: string, ttlMs?: number) {
+    this.setSync(key, value, mode, ttlMs);
+    return 'OK';
+  }
+
+  async del(...keys: string[]) {
+    let deleted = 0;
+    for (const key of keys) deleted += this.delSync(key);
+    return deleted;
+  }
+
+  async unlink(...keys: string[]) {
+    return this.del(...keys);
+  }
+
+  async pexpire(key: string, ttlMs: number) {
+    this.pexpireSync(key, ttlMs);
+    return 1;
+  }
+
+  async scan(cursor: string, _match: string, pattern: string) {
+    const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;
+    const keys = [
+      ...this.values.keys(),
+      ...this.hashes.keys(),
+      ...this.zsets.keys(),
+    ].filter((key, index, all) => all.indexOf(key) === index);
+    return [
+      '0',
+      cursor === '0' ? keys.filter((key) => key.startsWith(prefix)) : [],
+    ];
+  }
+
+  async zrangebyscore(key: string, min: number, max: number) {
+    return [...(this.zsets.get(key)?.entries() ?? [])]
+      .filter(([, score]) => score >= min && score <= max)
+      .sort((a, b) => a[1] - b[1])
+      .map(([member]) => member);
+  }
+
+  async zrem(key: string, member: string) {
+    return this.zsets.get(key)?.delete(member) ? 1 : 0;
+  }
+
+  setSync(key: string, value: string, mode?: string, ttlMs?: number) {
+    this.values.set(key, value);
+    if (mode === 'PX' && typeof ttlMs === 'number') {
+      this.pexpireSync(key, ttlMs);
+    }
+  }
+
+  zaddSync(key: string, score: number, member: string) {
+    const zset = this.zsets.get(key) ?? new Map<string, number>();
+    zset.set(member, score);
+    this.zsets.set(key, zset);
+  }
+
+  hsetSync(key: string, value: Record<string, string>) {
+    const hash = this.hashes.get(key) ?? new Map<string, string>();
+    for (const [field, fieldValue] of Object.entries(value)) {
+      hash.set(field, fieldValue);
+    }
+    this.hashes.set(key, hash);
+  }
+
+  pexpireSync(key: string, ttlMs: number) {
+    this.expiries.set(key, ttlMs);
+  }
+
+  delSync(key: string) {
+    const existed =
+      this.values.delete(key) ||
+      this.hashes.delete(key) ||
+      this.zsets.delete(key);
+    this.expiries.delete(key);
+    return existed ? 1 : 0;
+  }
+}
+
+function createService(redis: FakeRedis, nodeName = 'app-a') {
+  return new RuntimeNamespaceLifecycleService({
+    redis: redis as any,
+    instanceService: { getInstanceId: () => 'inst-a' } as any,
+    envService: {
+      get: (key: string) => {
+        if (key === 'NODE_NAME') return nodeName;
+        if (key === 'REDIS_NAMESPACE_KEY_TTL_MS') return 10000;
+        if (key === 'REDIS_NAMESPACE_LEASE_TTL_MS') return 1000;
+        if (key === 'REDIS_NAMESPACE_RENEW_INTERVAL_MS') return 1000000;
+        if (key === 'REDIS_NAMESPACE_JANITOR_INTERVAL_MS') return 1000000;
+        if (key === 'REDIS_NAMESPACE_STALE_GRACE_MS') return 5000;
+        return undefined;
+      },
+    } as any,
+  });
+}
+
+describe('RuntimeNamespaceLifecycleService', () => {
+  it('renews TTL for Enfyra-owned keys in the current namespace', async () => {
+    const redis = new FakeRedis();
+    redis.values.set('app-a:runtime_cache:metadata', 'cache');
+    redis.values.set('app-a:sys_flow-execution:completed', 'queue');
+    redis.values.set('other:runtime_cache:metadata', 'other');
+
+    const service = createService(redis);
+
+    await service.renewCurrentNamespaceKeys();
+
+    expect(redis.expiries.get('app-a:runtime_cache:metadata')).toBe(10000);
+    expect(redis.expiries.get('app-a:sys_flow-execution:completed')).toBe(
+      10000,
+    );
+    expect(redis.expiries.has('other:runtime_cache:metadata')).toBe(false);
+    expect(redis.values.has('app-a:runtime_lifecycle:lease:inst-a')).toBe(true);
+    expect(redis.zsets.get('enfyra:runtime_namespaces')?.has('app-a')).toBe(
+      true,
+    );
+  });
+
+  it('cleans stale Enfyra-owned namespace keys without touching custom keys', async () => {
+    const redis = new FakeRedis();
+    redis.zaddSync('enfyra:runtime_namespaces', 1000, 'old-app');
+    redis.zaddSync('enfyra:runtime_namespaces', 1000, 'active-app');
+    redis.values.set('old-app:runtime_cache:metadata', 'cache');
+    redis.values.set('old-app:sys_session-cleanup:completed', 'queue');
+    redis.values.set('old-app:custom:key', 'custom');
+    redis.values.set('active-app:runtime_cache:metadata', 'cache');
+    redis.values.set('active-app:runtime_lifecycle:lease:inst-b', 'lease');
+
+    const service = createService(redis, 'app-a');
+    const result = await service.cleanupStaleNamespaces(7000);
+
+    expect(result).toEqual([{ namespace: 'old-app', deleted: 2 }]);
+    expect(redis.values.has('old-app:runtime_cache:metadata')).toBe(false);
+    expect(redis.values.has('old-app:sys_session-cleanup:completed')).toBe(
+      false,
+    );
+    expect(redis.values.get('old-app:custom:key')).toBe('custom');
+    expect(redis.values.get('active-app:runtime_cache:metadata')).toBe('cache');
+    expect(redis.zsets.get('enfyra:runtime_namespaces')?.has('old-app')).toBe(
+      false,
+    );
+  });
+});

--- a/test/cache/runtime-namespace-lifecycle.service.spec.ts
+++ b/test/cache/runtime-namespace-lifecycle.service.spec.ts
@@ -131,8 +131,6 @@ function createService(redis: FakeRedis, nodeName = 'app-a') {
         if (key === 'REDIS_NAMESPACE_KEY_TTL_MS') return 10000;
         if (key === 'REDIS_NAMESPACE_LEASE_TTL_MS') return 1000;
         if (key === 'REDIS_NAMESPACE_RENEW_INTERVAL_MS') return 1000000;
-        if (key === 'REDIS_NAMESPACE_JANITOR_INTERVAL_MS') return 1000000;
-        if (key === 'REDIS_NAMESPACE_STALE_GRACE_MS') return 5000;
         if (key === 'NODE_ENV') return 'test';
         return undefined;
       },
@@ -157,33 +155,21 @@ describe('RuntimeNamespaceLifecycleService', () => {
     );
     expect(redis.expiries.has('other:runtime_cache:metadata')).toBe(false);
     expect(redis.values.has('app-a:runtime_lifecycle:lease:inst-a')).toBe(true);
-    expect(redis.zsets.get('enfyra:runtime_namespaces')?.has('app-a')).toBe(
-      true,
-    );
   });
 
-  it('cleans stale Enfyra-owned namespace keys without touching custom keys', async () => {
+  it('renews existing lifecycle keys for the same namespace after restart', async () => {
     const redis = new FakeRedis();
-    redis.zaddSync('enfyra:runtime_namespaces', 1000, 'old-app');
-    redis.zaddSync('enfyra:runtime_namespaces', 1000, 'active-app');
-    redis.values.set('old-app:runtime_cache:metadata', 'cache');
-    redis.values.set('old-app:sys_session-cleanup:completed', 'queue');
-    redis.values.set('old-app:custom:key', 'custom');
-    redis.values.set('active-app:runtime_cache:metadata', 'cache');
-    redis.values.set('active-app:runtime_lifecycle:lease:inst-b', 'lease');
+    redis.values.set('app-a:runtime_cache:metadata', 'old-cache');
+    redis.values.set('app-a:sys_session-cleanup:completed', 'old-queue');
+    redis.expiries.set('app-a:runtime_cache:metadata', 100);
+    redis.expiries.set('app-a:sys_session-cleanup:completed', 100);
 
-    const service = createService(redis, 'app-a');
-    const result = await service.cleanupStaleNamespaces(7000);
+    const restartedService = createService(redis, 'app-a');
+    await restartedService.renewCurrentNamespaceKeys();
 
-    expect(result).toEqual([{ namespace: 'old-app', deleted: 2 }]);
-    expect(redis.values.has('old-app:runtime_cache:metadata')).toBe(false);
-    expect(redis.values.has('old-app:sys_session-cleanup:completed')).toBe(
-      false,
-    );
-    expect(redis.values.get('old-app:custom:key')).toBe('custom');
-    expect(redis.values.get('active-app:runtime_cache:metadata')).toBe('cache');
-    expect(redis.zsets.get('enfyra:runtime_namespaces')?.has('old-app')).toBe(
-      false,
+    expect(redis.expiries.get('app-a:runtime_cache:metadata')).toBe(10000);
+    expect(redis.expiries.get('app-a:sys_session-cleanup:completed')).toBe(
+      10000,
     );
   });
 

--- a/test/cache/runtime-namespace-lifecycle.service.spec.ts
+++ b/test/cache/runtime-namespace-lifecycle.service.spec.ts
@@ -133,6 +133,7 @@ function createService(redis: FakeRedis, nodeName = 'app-a') {
         if (key === 'REDIS_NAMESPACE_RENEW_INTERVAL_MS') return 1000000;
         if (key === 'REDIS_NAMESPACE_JANITOR_INTERVAL_MS') return 1000000;
         if (key === 'REDIS_NAMESPACE_STALE_GRACE_MS') return 5000;
+        if (key === 'NODE_ENV') return 'test';
         return undefined;
       },
     } as any,
@@ -140,7 +141,7 @@ function createService(redis: FakeRedis, nodeName = 'app-a') {
 }
 
 describe('RuntimeNamespaceLifecycleService', () => {
-  it('renews TTL for Enfyra-owned keys in the current namespace', async () => {
+  it('renews TTL for safe runtime keys in the current namespace', async () => {
     const redis = new FakeRedis();
     redis.values.set('app-a:runtime_cache:metadata', 'cache');
     redis.values.set('app-a:sys_flow-execution:completed', 'queue');

--- a/test/cache/runtime-namespace-lifecycle.service.spec.ts
+++ b/test/cache/runtime-namespace-lifecycle.service.spec.ts
@@ -186,4 +186,17 @@ describe('RuntimeNamespaceLifecycleService', () => {
       false,
     );
   });
+
+  it('renews one system queue namespace on demand', async () => {
+    const redis = new FakeRedis();
+    redis.values.set('app-a:sys_flow-execution:wait', 'queue');
+    redis.values.set('app-a:sys_session-cleanup:wait', 'queue');
+
+    const service = createService(redis);
+
+    await service.renewSystemQueueKeys('sys_flow-execution');
+
+    expect(redis.expiries.get('app-a:sys_flow-execution:wait')).toBe(10000);
+    expect(redis.expiries.has('app-a:sys_session-cleanup:wait')).toBe(false);
+  });
 });

--- a/test/cache/user-cache.service.spec.ts
+++ b/test/cache/user-cache.service.spec.ts
@@ -147,6 +147,10 @@ function makeService(limitMb: number, maxValueBytes = 0) {
           return undefined;
         },
       } as any,
+      runtimeNamespaceLifecycleService: {
+        getKeyTtlMs: () => 5000,
+        touchKeys: async () => undefined,
+      } as any,
     }),
   };
 }

--- a/test/cache/user-cache.service.spec.ts
+++ b/test/cache/user-cache.service.spec.ts
@@ -38,6 +38,11 @@ class FakePipeline {
     return this;
   }
 
+  pexpire(key: string, ttlMs: number) {
+    this.ops.push(() => this.redis.pexpireSync(key, ttlMs));
+    return this;
+  }
+
   async exec() {
     for (const op of this.ops) op();
     return [];
@@ -48,6 +53,7 @@ class FakeRedis {
   strings = new Map<string, string>();
   hashes = new Map<string, Map<string, string>>();
   zsets = new Map<string, Map<string, number>>();
+  expiries = new Map<string, number>();
 
   pipeline() {
     return new FakePipeline(this);
@@ -56,6 +62,10 @@ class FakeRedis {
   async set(key: string, value: string, ...args: any[]) {
     if (args.includes('NX') && this.strings.has(key)) return null;
     this.strings.set(key, value);
+    const pxIndex = args.indexOf('PX');
+    if (pxIndex >= 0 && typeof args[pxIndex + 1] === 'number') {
+      this.pexpireSync(key, args[pxIndex + 1]);
+    }
     return 'OK';
   }
 
@@ -131,6 +141,12 @@ class FakeRedis {
     const next = Number(this.strings.get(key) ?? 0) + amount;
     this.strings.set(key, String(next));
   }
+
+  pexpireSync(key: string, ttlMs: number) {
+    if (this.strings.has(key) || this.hashes.has(key) || this.zsets.has(key)) {
+      this.expiries.set(key, ttlMs);
+    }
+  }
 }
 
 function makeService(limitMb: number, maxValueBytes = 0) {
@@ -149,7 +165,6 @@ function makeService(limitMb: number, maxValueBytes = 0) {
       } as any,
       runtimeNamespaceLifecycleService: {
         getKeyTtlMs: () => 5000,
-        touchKeys: async () => undefined,
       } as any,
     }),
   };
@@ -164,7 +179,34 @@ describe('UserCacheService', () => {
     expect(redis.strings.get('app-a:user_cache:feature')).toBe(
       '{"enabled":true}',
     );
+    expect(redis.expiries.get('app-a:user_cache:feature')).toBe(1000);
     expect(await service.get('feature')).toEqual({ enabled: true });
+  });
+
+  it('stores zero-ttl values and user cache metadata with lifecycle ttl', async () => {
+    const { redis, service } = makeService(1);
+
+    await service.set('feature', { enabled: true }, 0);
+
+    expect(redis.expiries.get('app-a:user_cache:feature')).toBe(5000);
+    expect(redis.expiries.get('app-a:user_cache_meta:lru')).toBe(5000);
+    expect(redis.expiries.get('app-a:user_cache_meta:sizes')).toBe(5000);
+    expect(redis.expiries.get('app-a:user_cache_meta:total_bytes')).toBe(5000);
+  });
+
+  it('repairs lifecycle ttl when untracking stale user cache metadata', async () => {
+    const { redis, service } = makeService(1);
+    const key = 'app-a:user_cache:ghost';
+
+    redis.hsetSync('app-a:user_cache_meta:sizes', key, '4');
+    redis.zaddSync('app-a:user_cache_meta:lru', 1, key);
+    redis.strings.set('app-a:user_cache_meta:total_bytes', '4');
+
+    await service.deleteKey('ghost');
+
+    expect(redis.expiries.get('app-a:user_cache_meta:lru')).toBe(5000);
+    expect(redis.expiries.get('app-a:user_cache_meta:sizes')).toBe(5000);
+    expect(redis.expiries.get('app-a:user_cache_meta:total_bytes')).toBe(5000);
   });
 
   it('evicts least recently used keys when the user cache quota is exceeded', async () => {
@@ -193,5 +235,13 @@ describe('UserCacheService', () => {
     expect(await service.get('lock')).toBe('a');
     expect(await service.release('lock', 'a')).toBe(true);
     expect(await service.get('lock')).toBeNull();
+  });
+
+  it('acquires zero-ttl locks with lifecycle ttl', async () => {
+    const { redis, service } = makeService(1);
+
+    expect(await service.acquire('lock', 'a', 0)).toBe(true);
+
+    expect(redis.expiries.get('app-a:user_cache:lock')).toBe(5000);
   });
 });

--- a/test/domain/oauth-exchange-code.service.spec.ts
+++ b/test/domain/oauth-exchange-code.service.spec.ts
@@ -3,10 +3,19 @@ import { OAuthExchangeCodeService } from '../../src/domain/auth';
 
 function createHarness() {
   const store = new Map<string, any>();
+  const pipeline = {
+    zadd: vi.fn(() => pipeline),
+    pexpire: vi.fn(() => pipeline),
+    exec: vi.fn(async () => []),
+  };
   const redis = {
     zadd: vi.fn(async () => 1),
     zrangebyscore: vi.fn(async () => [] as string[]),
     zrem: vi.fn(async () => 1),
+    zcard: vi.fn(async () => 0),
+    pexpire: vi.fn(async () => 1),
+    del: vi.fn(async () => 1),
+    pipeline: vi.fn(() => pipeline),
   };
   const cacheService = {
     get: vi.fn(async (key: string) => store.get(key) ?? null),
@@ -30,12 +39,12 @@ function createHarness() {
     envService: envService as any,
   });
 
-  return { service, redis, cacheService, queryBuilderService, store };
+  return { service, redis, pipeline, cacheService, queryBuilderService, store };
 }
 
 describe('OAuthExchangeCodeService', () => {
   it('stores exchange tokens behind a temporary code', async () => {
-    const { service, redis, cacheService } = createHarness();
+    const { service, pipeline, cacheService } = createHarness();
     const code = await service.createCodeForTokens({
       accessToken: 'access',
       refreshToken: 'refresh',
@@ -47,14 +56,27 @@ describe('OAuthExchangeCodeService', () => {
     expect(code).toEqual(expect.any(String));
     expect(cacheService.set).toHaveBeenCalledWith(
       `auth:oauth-exchange:code:${code}`,
-      expect.objectContaining({ accessToken: 'access', sessionId: 'session-1' }),
+      expect.objectContaining({
+        accessToken: 'access',
+        sessionId: 'session-1',
+      }),
       600000,
     );
-    expect(redis.zadd).toHaveBeenCalledWith(
+    expect(cacheService.set).toHaveBeenCalledWith(
+      `auth:oauth-exchange:pending:${code}`,
+      expect.objectContaining({ sessionId: 'session-1' }),
+      1200000,
+    );
+    expect(pipeline.zadd).toHaveBeenCalledWith(
       'auth:oauth-exchange:pending-index',
       expect.any(Number),
       code,
     );
+    expect(pipeline.pexpire).toHaveBeenCalledWith(
+      'auth:oauth-exchange:pending-index',
+      1200000,
+    );
+    expect(pipeline.exec).toHaveBeenCalledTimes(1);
   });
 
   it('deletes the temporary code when exchange succeeds', async () => {
@@ -94,5 +116,6 @@ describe('OAuthExchangeCodeService', () => {
       'session-1',
     );
     expect(store.has('auth:oauth-exchange:pending:expired-code')).toBe(false);
+    expect(redis.del).toHaveBeenCalledWith('auth:oauth-exchange:pending-index');
   });
 });

--- a/test/domain/system-safety-auditor-system-flag.spec.ts
+++ b/test/domain/system-safety-auditor-system-flag.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { SystemSafetyAuditorService } from '../../src/domain/policy/services/system-safety-auditor.service';
 
 function makeService(tableColumns: any[] = [{ name: 'isSystem' }]) {
-  const metadataCacheService = {
-    getMetadata: vi.fn().mockResolvedValue({
+  const runtimeRegistryService = {
+    requireMetadata: vi.fn().mockReturnValue({
       tables: new Map([
         [
           'app_user',
@@ -30,7 +30,7 @@ function makeService(tableColumns: any[] = [{ name: 'isSystem' }]) {
   return {
     service: new SystemSafetyAuditorService({
       commonService: commonService as any,
-      metadataCacheService: metadataCacheService as any,
+      runtimeRegistryService: runtimeRegistryService as any,
       schemaMigrationValidatorService: schemaMigrationValidatorService as any,
     }),
     commonService,

--- a/test/flow-engine/flow-scheduler.service.spec.ts
+++ b/test/flow-engine/flow-scheduler.service.spec.ts
@@ -22,27 +22,38 @@ function createScheduler(options?: {
   const runtimeRegistryService = {
     requireActiveData: vi.fn(() => options?.flows || []),
   };
+  const runtimeNamespaceLifecycleService = {
+    renewSystemQueueKeys: vi.fn(async () => undefined),
+  };
   const service = new FlowSchedulerService({
     eventEmitter,
     flowQueue: flowQueue as any,
     runtimeRegistryService: runtimeRegistryService as any,
+    runtimeNamespaceLifecycleService: runtimeNamespaceLifecycleService as any,
   });
 
-  return { eventEmitter, flowQueue, runtimeRegistryService, service };
+  return {
+    eventEmitter,
+    flowQueue,
+    runtimeRegistryService,
+    runtimeNamespaceLifecycleService,
+    service,
+  };
 }
 
 describe('FlowSchedulerService', () => {
   it('registers scheduled flows during init even if FLOW_LOADED already happened', async () => {
-    const { service, flowQueue } = createScheduler({
-      flows: [
-        {
-          id: 6,
-          name: 'cloud-reconcile-hosts',
-          triggerType: 'schedule',
-          triggerConfig: { cron: '*/15 * * * *', timezone: 'UTC' },
-        },
-      ],
-    });
+    const { service, flowQueue, runtimeNamespaceLifecycleService } =
+      createScheduler({
+        flows: [
+          {
+            id: 6,
+            name: 'cloud-reconcile-hosts',
+            triggerType: 'schedule',
+            triggerConfig: { cron: '*/15 * * * *', timezone: 'UTC' },
+          },
+        ],
+      });
 
     await service.init();
 
@@ -64,6 +75,9 @@ describe('FlowSchedulerService', () => {
         registeredCount: 1,
       }),
     );
+    expect(
+      runtimeNamespaceLifecycleService.renewSystemQueueKeys,
+    ).toHaveBeenCalledWith('sys_flow-execution');
   });
 
   it('removes existing flow schedulers before rebuilding schedules', async () => {

--- a/test/guards/guard-evaluator.service.spec.ts
+++ b/test/guards/guard-evaluator.service.spec.ts
@@ -104,7 +104,7 @@ describe('GuardEvaluatorService', () => {
     });
 
     it('should reject with 429 when rate limit exceeded', async () => {
-      rateLimitService.setResult('ip:1.2.3.4:/test', false);
+      rateLimitService.setResult('guard_rule:1:ip:1.2.3.4', false);
       const guard = makeGuard({
         rules: [
           makeRule({
@@ -136,7 +136,7 @@ describe('GuardEvaluatorService', () => {
         routePath: '/test',
         userId: 'user-123',
       });
-      expect(rateLimitService.calledKeys).toContain('user:user-123:/test');
+      expect(rateLimitService.calledKeys).toContain('guard_rule:1:user:user-123');
     });
 
     it('should use correct key for rate_limit_by_route', async () => {
@@ -152,7 +152,34 @@ describe('GuardEvaluatorService', () => {
         clientIp: '1.2.3.4',
         routePath: '/api/posts',
       });
-      expect(rateLimitService.calledKeys).toContain('route:/api/posts');
+      expect(rateLimitService.calledKeys).toContain('guard_rule:1:route:/api/posts');
+    });
+
+    it('should scope IP counters by guard rule instead of route path', async () => {
+      const guard = makeGuard({
+        isGlobal: true,
+        rules: [
+          makeRule({
+            id: 9,
+            type: 'rate_limit_by_ip',
+            config: { maxRequests: 100, perSeconds: 60 },
+          }),
+        ],
+      });
+
+      await evaluator.evaluateGuard(guard, {
+        clientIp: '1.2.3.4',
+        routePath: '/metadata',
+      });
+      await evaluator.evaluateGuard(guard, {
+        clientIp: '1.2.3.4',
+        routePath: '/enfyra_menu',
+      });
+
+      expect(rateLimitService.calledKeys).toEqual([
+        'guard_rule:9:ip:1.2.3.4',
+        'guard_rule:9:ip:1.2.3.4',
+      ]);
     });
 
     it('should skip rule with missing config', async () => {
@@ -333,7 +360,7 @@ describe('GuardEvaluatorService', () => {
     });
 
     it('should reject on first failing rule (short-circuit)', async () => {
-      rateLimitService.setResult('ip:1.2.3.4:/test', false);
+      rateLimitService.setResult('guard_rule:10:ip:1.2.3.4', false);
       const guard = makeGuard({
         combinator: 'and',
         rules: [
@@ -361,7 +388,7 @@ describe('GuardEvaluatorService', () => {
 
   describe('cost-based rule ordering', () => {
     it('should evaluate IP rules before rate limit rules (AND)', async () => {
-      rateLimitService.setResult('ip:1.2.3.4:/test', false);
+      rateLimitService.setResult('guard_rule:1:ip:1.2.3.4', false);
       const guard = makeGuard({
         combinator: 'and',
         rules: [
@@ -416,7 +443,7 @@ describe('GuardEvaluatorService', () => {
     });
 
     it('should skip rate limit when IP whitelist passes (OR)', async () => {
-      rateLimitService.setResult('ip:10.0.0.1:/test', false);
+      rateLimitService.setResult('guard_rule:1:ip:10.0.0.1', false);
       const guard = makeGuard({
         combinator: 'or',
         rules: [
@@ -442,7 +469,7 @@ describe('GuardEvaluatorService', () => {
     });
 
     it('should still call rate limit when IP check passes (AND)', async () => {
-      rateLimitService.setResult('ip:10.0.0.1:/test', false);
+      rateLimitService.setResult('guard_rule:1:ip:10.0.0.1', false);
       const guard = makeGuard({
         combinator: 'and',
         rules: [
@@ -521,7 +548,7 @@ describe('GuardEvaluatorService', () => {
 
   describe('nested guard tree', () => {
     it('should evaluate (rate_limit AND rate_limit_by_route) OR ip_whitelist', async () => {
-      rateLimitService.setResult('ip:1.2.3.4:/test', false);
+      rateLimitService.setResult('guard_rule:10:ip:1.2.3.4', false);
 
       const guard = makeGuard({
         combinator: 'or',
@@ -568,7 +595,7 @@ describe('GuardEvaluatorService', () => {
     });
 
     it('should reject when nested OR has no passing branch', async () => {
-      rateLimitService.setResult('ip:1.2.3.4:/test', false);
+      rateLimitService.setResult('guard_rule:10:ip:1.2.3.4', false);
 
       const guard = makeGuard({
         combinator: 'or',
@@ -677,7 +704,7 @@ describe('GuardEvaluatorService', () => {
 
   describe('user scoping', () => {
     it('should apply rule only to specified users', async () => {
-      rateLimitService.setResult('user:user-A:/test', false);
+      rateLimitService.setResult('guard_rule:1:user:user-A', false);
       const guard = makeGuard({
         rules: [
           makeRule({
@@ -723,7 +750,7 @@ describe('GuardEvaluatorService', () => {
     });
 
     it('should apply rule to all users when userIds is empty', async () => {
-      rateLimitService.setResult('user:user-X:/test', false);
+      rateLimitService.setResult('guard_rule:1:user:user-X', false);
       const guard = makeGuard({
         rules: [
           makeRule({

--- a/test/http/admin-test-run.spec.ts
+++ b/test/http/admin-test-run.spec.ts
@@ -60,8 +60,8 @@ describe('admin test run', () => {
   it('resolves saved route handler code and runs it with HTTP-like context', async () => {
     const cradle = {
       executorEngineService: new InlineExecutor(),
-      routeCacheService: {
-        getRoutes: async () => [
+      runtimeRegistryService: {
+        getRoutes: () => [
           {
             id: 1,
             path: '/orders',
@@ -107,8 +107,8 @@ describe('admin test run', () => {
   it('resolves saved websocket event code and runs it with websocket context', async () => {
     const cradle = {
       executorEngineService: new InlineExecutor(),
-      websocketCacheBuilder: {
-        getGateways: async () => [
+      runtimeRegistryService: {
+        getActiveData: () => [
           {
             id: 1,
             path: '/ws',

--- a/test/knex/sql-pool-cluster-coordinator.service.spec.ts
+++ b/test/knex/sql-pool-cluster-coordinator.service.spec.ts
@@ -3,6 +3,50 @@ import { SqlPoolClusterCoordinatorService } from '../../src/engines/knex';
 
 class FakeRedis {
   zsets = new Map<string, Map<string, number>>();
+  expiries = new Map<string, number>();
+
+  pipeline() {
+    const ops: Array<() => void> = [];
+    return {
+      zadd: (key: string, score: number, member: string) => {
+        ops.push(() => {
+          const zset = this.zsets.get(key) ?? new Map<string, number>();
+          zset.set(member, score);
+          this.zsets.set(key, zset);
+        });
+        return this.pipelineProxy(ops);
+      },
+      pexpire: (key: string, ttlMs: number) => {
+        ops.push(() => this.expiries.set(key, ttlMs));
+        return this.pipelineProxy(ops);
+      },
+      exec: async () => {
+        for (const op of ops) op();
+        return [];
+      },
+    };
+  }
+
+  private pipelineProxy(ops: Array<() => void>): any {
+    return {
+      zadd: (key: string, score: number, member: string) => {
+        ops.push(() => {
+          const zset = this.zsets.get(key) ?? new Map<string, number>();
+          zset.set(member, score);
+          this.zsets.set(key, zset);
+        });
+        return this.pipelineProxy(ops);
+      },
+      pexpire: (key: string, ttlMs: number) => {
+        ops.push(() => this.expiries.set(key, ttlMs));
+        return this.pipelineProxy(ops);
+      },
+      exec: async () => {
+        for (const op of ops) op();
+        return [];
+      },
+    };
+  }
 
   async zadd(key: string, score: number, member: string) {
     const zset = this.zsets.get(key) ?? new Map<string, number>();
@@ -26,6 +70,11 @@ class FakeRedis {
       }
     }
     return removed;
+  }
+
+  async pexpire(key: string, ttlMs: number) {
+    this.expiries.set(key, ttlMs);
+    return 1;
   }
 
   async zcard(key: string) {
@@ -98,6 +147,7 @@ describe('SqlPoolClusterCoordinatorService', () => {
       }),
     );
     const appAStats = await appA.getClusterStats();
+    expect(redis.expiries.get(appAStats.key)).toBeGreaterThan(0);
     expect(appAStats.instances).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: 'app-b:same-instance' }),

--- a/test/mongo/mongo-hook-manager.service.spec.ts
+++ b/test/mongo/mongo-hook-manager.service.spec.ts
@@ -12,9 +12,9 @@ function makeService() {
     ],
     relations: [],
   };
-  const metadataCacheService = {
-    lookupTableByName: vi.fn().mockResolvedValue(metadata),
-    getTableMetadata: vi.fn().mockResolvedValue(metadata),
+  const runtimeRegistryService = {
+    lookupTableByName: vi.fn(() => metadata),
+    getTableMetadata: vi.fn(() => metadata),
   };
   const relationManager = {
     stripInverseRelations: vi.fn(async (_table, data) => data),
@@ -43,7 +43,7 @@ function makeService() {
   const service = new MongoService({
     envService: {} as any,
     databaseConfigService: {} as any,
-    metadataCacheService: metadataCacheService as any,
+    runtimeRegistryService: runtimeRegistryService as any,
     mongoRelationManagerService: relationManager as any,
     lazyRef: {} as any,
   });

--- a/test/mongo/mongo-relation-manager.service.spec.ts
+++ b/test/mongo/mongo-relation-manager.service.spec.ts
@@ -31,13 +31,13 @@ function makeService() {
       },
     ],
   };
-  const metadataCacheService = {
-    lookupTableByName: vi.fn(async (name: string) =>
+  const runtimeRegistryService = {
+    lookupTableByName: vi.fn((name: string) =>
       name === 'post' ? postMeta : { name, relations: [] },
     ),
   };
   const service = new MongoRelationManagerService({
-    metadataCacheService: metadataCacheService as any,
+    runtimeRegistryService: runtimeRegistryService as any,
   });
   return { service };
 }

--- a/test/mongo/strip-unknown-columns.spec.ts
+++ b/test/mongo/strip-unknown-columns.spec.ts
@@ -6,8 +6,8 @@ function makeService(metadata: any): MongoService {
   return new MongoService({
     envService: {} as any,
     databaseConfigService: {} as any,
-    metadataCacheService: {
-      lookupTableByName: async () => metadata,
+    runtimeRegistryService: {
+      lookupTableByName: () => metadata,
     } as any,
     mongoRelationManagerService: {} as any,
     lazyRef: {} as any,


### PR DESCRIPTION
- Updated session cleanup service to include job options for removing completed and failed jobs.
- Modified cache service to utilize runtime namespace lifecycle service for setting TTL on cache entries.
- Refactored guard evaluator service to scope rate limit keys by guard rule ID.
- Added runtime namespace lifecycle service to manage key TTLs and cleanup stale namespaces.
- Enhanced Redis admin service to filter keys based on system kind and added new filtering capabilities.
- Introduced tests for runtime namespace lifecycle service to ensure proper key renewal and cleanup functionality.