### PR TITLE
feat: update @enfyra/kernel to version 1.1.31 and add benchmark scrip…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.2.11-patch-1",
+  "version": "2.2.11-patch-2",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "license": "SEE LICENSE IN LICENSE",
@@ -32,6 +32,7 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "lint:unused": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c eslint.unused-only.mjs --max-warnings 99999",
     "bench:executor": "NODE_OPTIONS=\"--no-node-snapshot --expose-gc\" node scripts/bench-handler-worker-memory.mjs",
+    "bench:m2m-pg": "NODE_OPTIONS=\"--no-node-snapshot\" node scripts/benchmark-m2m-dataloader-pg.mjs",
     "test": "node scripts/test-prompt.js",
     "test:all": "NODE_OPTIONS=\"--no-node-snapshot${NODE_OPTIONS:+ $NODE_OPTIONS}\" vitest run",
     "test:watch": "NODE_OPTIONS=\"--no-node-snapshot${NODE_OPTIONS:+ $NODE_OPTIONS}\" vitest",
@@ -48,7 +49,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1024.0",
     "@aws-sdk/lib-storage": "3.1024.0",
-    "@enfyra/kernel": "1.1.30",
+    "@enfyra/kernel": "1.1.31",
     "@envelop/core": "^5.5.1",
     "@envelop/depth-limit": "^7.1.1",
     "@google-cloud/storage": "^7.19.0",

--- a/scripts/benchmark-m2m-dataloader-pg.mjs
+++ b/scripts/benchmark-m2m-dataloader-pg.mjs
@@ -1,0 +1,463 @@
+import knex from 'knex';
+import { executeBatchFetches } from '@enfyra/kernel';
+import { performance } from 'node:perf_hooks';
+
+const connection =
+  process.env.PG_TEST_URI || 'postgresql://root:1234@localhost:5432/postgres';
+const postCount = Number(process.env.M2M_BENCH_POSTS || 100_000);
+const targetCount = Number(process.env.M2M_BENCH_TARGETS || 2_000_000);
+const fanout = Number(process.env.M2M_BENCH_FANOUT || 200);
+const sampleParentCount = Number(process.env.M2M_BENCH_SAMPLE_PARENTS || 2_000);
+const relationLimit = Number(process.env.M2M_BENCH_LIMIT || 10);
+const measuredRuns = Number(process.env.M2M_BENCH_RUNS || 3);
+const perParentConcurrency = Number(
+  process.env.M2M_BENCH_PER_PARENT_CONCURRENCY || 16,
+);
+const sharedTopTargets = process.env.M2M_BENCH_SHARED_TOP !== '0';
+const keepSchema = process.env.M2M_BENCH_KEEP_SCHEMA === '1';
+const schema = `__m2m_bench_${Date.now()}`;
+const postsTable = `${schema}.posts`;
+const targetsTable = `${schema}.comments`;
+const junctionTable = `${schema}.post_comments`;
+
+if (
+  !Number.isInteger(postCount) ||
+  !Number.isInteger(targetCount) ||
+  !Number.isInteger(fanout) ||
+  !Number.isInteger(sampleParentCount) ||
+  postCount < 1 ||
+  targetCount <= 4_000 ||
+  fanout < 20 ||
+  sampleParentCount < 1 ||
+  sampleParentCount > postCount ||
+  relationLimit < 1
+) {
+  throw new Error('Invalid M2M benchmark dimensions');
+}
+
+const db = knex({
+  client: 'pg',
+  connection,
+  pool: { min: 0, max: 4 },
+});
+const quotedSchema = `"${schema}"`;
+const quotedPosts = `${quotedSchema}."posts"`;
+const quotedTargets = `${quotedSchema}."comments"`;
+const quotedJunction = `${quotedSchema}."post_comments"`;
+const parentIds = Array.from(
+  { length: sampleParentCount },
+  (_, index) => index + 1,
+);
+
+const metadata = {
+  [postsTable]: {
+    name: postsTable,
+    columns: [{ name: 'id', type: 'integer', isPrimary: true }],
+    relations: [
+      {
+        propertyName: 'comments',
+        type: 'many-to-many',
+        targetTableName: targetsTable,
+        targetTable: targetsTable,
+        junctionTableName: junctionTable,
+        junctionSourceColumn: 'post_id',
+        junctionTargetColumn: 'comment_id',
+        isInverse: false,
+      },
+    ],
+  },
+  [targetsTable]: {
+    name: targetsTable,
+    columns: [
+      { name: 'id', type: 'integer', isPrimary: true },
+      { name: 'score', type: 'integer' },
+      { name: 'payload', type: 'text' },
+    ],
+    relations: [],
+  },
+};
+const metadataGetter = async (table) => metadata[table] || null;
+
+const edgeTopKSql = `
+  SELECT source_id, target_id
+  FROM (
+    SELECT
+      junction.post_id AS source_id,
+      junction.comment_id AS target_id,
+      ROW_NUMBER() OVER (
+        PARTITION BY junction.post_id
+        ORDER BY target.score DESC, target.id ASC
+      ) AS relation_rank
+    FROM ${quotedJunction} AS junction
+    JOIN ${quotedTargets} AS target
+      ON target.id = junction.comment_id
+    WHERE junction.post_id = ANY(?::int[])
+  ) AS ranked
+  WHERE relation_rank <= ?
+  ORDER BY source_id, relation_rank
+`;
+
+const joinedTopKSql = `
+  SELECT source_id, id, score, payload
+  FROM (
+    SELECT
+      junction.post_id AS source_id,
+      target.id,
+      target.score,
+      target.payload,
+      ROW_NUMBER() OVER (
+        PARTITION BY junction.post_id
+        ORDER BY target.score DESC, target.id ASC
+      ) AS relation_rank
+    FROM ${quotedJunction} AS junction
+    JOIN ${quotedTargets} AS target
+      ON target.id = junction.comment_id
+    WHERE junction.post_id = ANY(?::int[])
+  ) AS ranked
+  WHERE relation_rank <= ?
+  ORDER BY source_id, relation_rank
+`;
+
+const perParentSql = `
+  SELECT target.id, target.score, target.payload
+  FROM ${quotedJunction} AS junction
+  JOIN ${quotedTargets} AS target
+    ON target.id = junction.comment_id
+  WHERE junction.post_id = ?
+  ORDER BY target.score DESC, target.id ASC
+  LIMIT ?
+`;
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function percentile(values, ratio) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.ceil(sorted.length * ratio) - 1];
+}
+
+async function countedRun(run) {
+  let queries = 0;
+  const countQuery = () => {
+    queries += 1;
+  };
+  db.on('query', countQuery);
+  const started = performance.now();
+  try {
+    const result = await run();
+    return {
+      ms: performance.now() - started,
+      queries,
+      ...result,
+    };
+  } finally {
+    db.removeListener('query', countQuery);
+  }
+}
+
+async function measure(name, run) {
+  await run();
+  const samples = [];
+  for (let index = 0; index < measuredRuns; index += 1) {
+    samples.push(await countedRun(run));
+  }
+  const durations = samples.map((sample) => sample.ms);
+  return {
+    name,
+    medianMs: Number(median(durations).toFixed(2)),
+    p95Ms: Number(percentile(durations, 0.95).toFixed(2)),
+    minMs: Number(Math.min(...durations).toFixed(2)),
+    maxMs: Number(Math.max(...durations).toFixed(2)),
+    queries: samples[0].queries,
+    relationRows: samples[0].relationRows,
+    uniqueTargets: samples[0].uniqueTargets,
+  };
+}
+
+async function runHybrid() {
+  const parents = parentIds.map((id) => ({ id }));
+  await executeBatchFetches(
+    db,
+    parents,
+    [
+      {
+        relationName: 'comments',
+        type: 'many-to-many',
+        targetTable: targetsTable,
+        fields: ['id', 'score', 'payload'],
+        junctionTableName: junctionTable,
+        junctionSourceColumn: 'post_id',
+        junctionTargetColumn: 'comment_id',
+        isInverse: false,
+        userSort: '-score',
+        userLimit: relationLimit,
+      },
+    ],
+    metadataGetter,
+    3,
+    0,
+    postsTable,
+    'postgres',
+    metadata,
+  );
+  const relationRows = parents.reduce(
+    (total, parent) => total + parent.comments.length,
+    0,
+  );
+  const uniqueTargets = new Set(
+    parents.flatMap((parent) => parent.comments.map((comment) => comment.id)),
+  ).size;
+  return { relationRows, uniqueTargets };
+}
+
+async function runJoinedTopK() {
+  const result = await db.raw(joinedTopKSql, [parentIds, relationLimit]);
+  return {
+    relationRows: result.rows.length,
+    uniqueTargets: new Set(result.rows.map((row) => row.id)).size,
+  };
+}
+
+async function runPerParent() {
+  const rows = new Array(parentIds.length);
+  let cursor = 0;
+  async function worker() {
+    while (cursor < parentIds.length) {
+      const index = cursor;
+      cursor += 1;
+      const result = await db.raw(perParentSql, [
+        parentIds[index],
+        relationLimit,
+      ]);
+      rows[index] = result.rows;
+    }
+  }
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(perParentConcurrency, parentIds.length),
+      },
+      worker,
+    ),
+  );
+  return {
+    relationRows: rows.reduce((total, row) => total + row.length, 0),
+    uniqueTargets: new Set(
+      rows.flatMap((row) => row.map((target) => target.id)),
+    ).size,
+  };
+}
+
+async function explain(sql, bindings) {
+  const result = await db.raw(
+    `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${sql}`,
+    bindings,
+  );
+  const report = result.rows[0]['QUERY PLAN'][0];
+  const plan = report.Plan;
+  return {
+    planningMs: report['Planning Time'],
+    executionMs: report['Execution Time'],
+    node: plan['Node Type'],
+    rows: plan['Actual Rows'],
+    sharedHitBlocks: plan['Shared Hit Blocks'] || 0,
+    sharedReadBlocks: plan['Shared Read Blocks'] || 0,
+    tempReadBlocks: plan['Temp Read Blocks'] || 0,
+    tempWrittenBlocks: plan['Temp Written Blocks'] || 0,
+  };
+}
+
+async function setup() {
+  console.log(
+    JSON.stringify({
+      stage: 'setup',
+      schema,
+      postCount,
+      targetCount,
+      fanout,
+      sharedTopTargets,
+      junctionRows: postCount * fanout,
+    }),
+  );
+  await db.raw(`CREATE SCHEMA ${quotedSchema}`);
+  await db.raw(`
+    CREATE UNLOGGED TABLE ${quotedPosts} (
+      id integer PRIMARY KEY
+    )
+  `);
+  await db.raw(`
+    CREATE UNLOGGED TABLE ${quotedTargets} (
+      id integer PRIMARY KEY,
+      score integer NOT NULL,
+      payload text NOT NULL
+    )
+  `);
+  await db.raw(`
+    CREATE UNLOGGED TABLE ${quotedJunction} (
+      post_id integer NOT NULL,
+      comment_id integer NOT NULL
+    )
+  `);
+
+  let started = performance.now();
+  await db.raw(
+    `
+    INSERT INTO ${quotedPosts} (id)
+    SELECT id
+    FROM generate_series(1, ?) AS id
+  `,
+    [postCount],
+  );
+  console.log(
+    JSON.stringify({
+      stage: 'insert-posts',
+      ms: Number((performance.now() - started).toFixed(2)),
+    }),
+  );
+
+  started = performance.now();
+  await db.raw(
+    `
+    INSERT INTO ${quotedTargets} (id, score, payload)
+    SELECT
+      id,
+      CASE
+        WHEN ?::boolean THEN
+          CASE
+            WHEN id <= 4000 THEN 10000000 - id
+            ELSE id % 1000000
+          END
+        ELSE ((id::bigint * 48271) % 2147483647)::integer
+      END,
+      repeat(md5(id::text), 4)
+    FROM generate_series(1, ?) AS id
+  `,
+    [sharedTopTargets, targetCount],
+  );
+  console.log(
+    JSON.stringify({
+      stage: 'insert-targets',
+      ms: Number((performance.now() - started).toFixed(2)),
+    }),
+  );
+
+  started = performance.now();
+  await db.raw(
+    `
+    INSERT INTO ${quotedJunction} (post_id, comment_id)
+    SELECT
+      post_id,
+      CASE
+        WHEN edge_number <= 20
+          THEN (((post_id - 1) % 200) * 20) + edge_number
+        ELSE 4001 + (
+          (
+            post_id::bigint * 7919 +
+            edge_number::bigint * 104729
+          ) % (? - 4000)
+        )::integer
+      END
+    FROM generate_series(1, ?) AS post_id
+    CROSS JOIN generate_series(1, ?) AS edge_number
+  `,
+    [targetCount, postCount, fanout],
+  );
+  console.log(
+    JSON.stringify({
+      stage: 'insert-junction',
+      rows: postCount * fanout,
+      ms: Number((performance.now() - started).toFixed(2)),
+    }),
+  );
+
+  started = performance.now();
+  await db.raw(`
+    SET maintenance_work_mem = '512MB';
+    CREATE INDEX post_comments_source_target_idx
+      ON ${quotedJunction} (post_id, comment_id);
+    ANALYZE ${quotedPosts};
+    ANALYZE ${quotedTargets};
+    ANALYZE ${quotedJunction};
+  `);
+  console.log(
+    JSON.stringify({
+      stage: 'index-analyze',
+      ms: Number((performance.now() - started).toFixed(2)),
+    }),
+  );
+}
+
+async function main() {
+  try {
+    const version = await db.raw('SELECT version() AS version');
+    console.log(
+      JSON.stringify({
+        stage: 'postgres',
+        version: version.rows[0].version,
+        poolMax: 4,
+      }),
+    );
+    await setup();
+
+    const size = await db.raw(
+      `
+      SELECT pg_size_pretty(sum(pg_total_relation_size(class.oid))) AS size
+      FROM pg_class AS class
+      JOIN pg_namespace AS namespace
+        ON namespace.oid = class.relnamespace
+      WHERE namespace.nspname = ?
+        AND class.relkind IN ('r', 'i')
+    `,
+      [schema],
+    );
+    console.log(
+      JSON.stringify({
+        stage: 'dataset-ready',
+        size: size.rows[0].size,
+        sharedTopTargets,
+        sampleParentCount,
+        candidateEdges: sampleParentCount * fanout,
+        requestedRows: sampleParentCount * relationLimit,
+      }),
+    );
+
+    const strategies = [
+      ['hybrid-edge-loader', runHybrid],
+      ['one-stage-joined-top-k', runJoinedTopK],
+      ['old-per-parent-c16', runPerParent],
+    ];
+    const results = [];
+    for (const [name, run] of strategies) {
+      const result = await measure(name, run);
+      results.push(result);
+      console.log(JSON.stringify({ stage: 'measurement', ...result }));
+    }
+
+    const edgePlan = await explain(edgeTopKSql, [parentIds, relationLimit]);
+    const joinedPlan = await explain(joinedTopKSql, [parentIds, relationLimit]);
+    console.log(
+      JSON.stringify({
+        stage: 'explain',
+        edgeTopK: edgePlan,
+        joinedTopK: joinedPlan,
+      }),
+    );
+    console.log(
+      JSON.stringify({
+        stage: 'summary',
+        datasetRows: postCount + targetCount + postCount * fanout,
+        results,
+      }),
+    );
+  } finally {
+    if (!keepSchema) {
+      await db.raw(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE`);
+      console.log(JSON.stringify({ stage: 'cleanup', schema }));
+    }
+    await db.destroy();
+  }
+}
+
+await main();

--- a/test/kernel/kernel-adversarial.spec.ts
+++ b/test/kernel/kernel-adversarial.spec.ts
@@ -1,4 +1,6 @@
 import {
+  BatchFetchEngine,
+  BatchExecutionBudget,
   CHUNKED_FETCH_CONCURRENCY,
   WHERE_IN_CHUNK_SIZE,
   chunkedFetch,
@@ -45,6 +47,21 @@ describe('kernel batch utilities adversarial behavior', () => {
 
     expect(maxActive).toBeLessThanOrEqual(CHUNKED_FETCH_CONCURRENCY);
     expect(maxActive).toBeGreaterThan(1);
+  });
+
+  test('chunkedFetch supports a caller-specific chunk size', async () => {
+    const chunks: number[][] = [];
+    const result = await chunkedFetch(
+      [1, 2, 3, 4, 5],
+      async (chunk: number[]) => {
+        chunks.push(chunk);
+        return chunk;
+      },
+      2,
+    );
+
+    expect(chunks).toEqual([[1, 2], [3, 4], [5]]);
+    expect(result).toEqual([1, 2, 3, 4, 5]);
   });
 
   test('chunkedFetch propagates fetch errors instead of returning partial data', async () => {
@@ -101,6 +118,43 @@ describe('kernel batch utilities adversarial behavior', () => {
     expect(result.size).toBe(0);
   });
 
+  test('BatchExecutionBudget caps aggregate relation I/O concurrency', async () => {
+    const budget = new BatchExecutionBudget(2);
+    let active = 0;
+    let maxActive = 0;
+
+    await Promise.all(
+      Array.from({ length: 8 }, () =>
+        budget.run(async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 3));
+          active -= 1;
+        }),
+      ),
+    );
+
+    expect(maxActive).toBe(2);
+  });
+
+  test('BatchExecutionBudget cancels queued relation I/O after a failure', async () => {
+    const budget = new BatchExecutionBudget(1);
+    let queuedTaskRan = false;
+
+    const results = await Promise.allSettled([
+      budget.run(async () => {
+        throw new Error('query failed');
+      }),
+      budget.run(async () => {
+        queuedTaskRan = true;
+      }),
+    ]);
+
+    expect(results[0].status).toBe('rejected');
+    expect(results[1].status).toBe('rejected');
+    expect(queuedTaskRan).toBe(false);
+  });
+
   test('parseBatchFields keeps root wildcards and groups nested paths by first relation', () => {
     const parsed = parseBatchFields([
       '*',
@@ -112,13 +166,128 @@ describe('kernel batch utilities adversarial behavior', () => {
     ]);
 
     expect(parsed.rootFields).toEqual(['*', 'id']);
-    expect(parsed.subRelations.get('author')).toEqual([
-      'name',
-      'company.name',
-    ]);
+    expect(parsed.subRelations.get('author')).toEqual(['name', 'company.name']);
     expect(parsed.subRelations.get('comments')).toEqual([
       'body',
       'author.name',
     ]);
+  });
+
+  test('BatchFetchEngine deduplicates inverse parent ids before adapter fetch', async () => {
+    let receivedParentIds: number[] = [];
+    const adapter: any = {
+      pkField: 'id',
+      keyOf: (value: any) => String(value),
+      buildScalarRef: (value: any) => ({ id: value }),
+      getTargetPkField: () => 'id',
+      resolveFields: () => ({
+        isPkOnly: false,
+        nestedDescs: [],
+        fetchSpec: { selectCols: ['id'], pkCol: 'id' },
+      }),
+      fetchOwner: async () => [],
+      fetchInverse: async (
+        _targetTable: string,
+        _fkField: string,
+        parentIds: number[],
+      ) => {
+        receivedParentIds = parentIds;
+        return {
+          docs: [{ id: 10, parentId: 1 }],
+          groupKeyField: 'parentId',
+        };
+      },
+      fetchM2M: async () => ({ grouped: new Map(), docs: [] }),
+      resolveOwnerFkKey: () => 'ownerId',
+      resolveInverseFkField: () => 'parentId',
+      resolveParentPk: () => 'id',
+    };
+    const metadataGetter = async (table: string) => ({
+      name: table,
+      columns: [{ name: 'id', type: 'integer' }],
+      relations: [],
+    });
+    const engine = new BatchFetchEngine(adapter, metadataGetter);
+    const parents = [{ id: 1 }, { id: 1 }];
+
+    await engine.execute(
+      parents,
+      [
+        {
+          relationName: 'children',
+          type: 'one-to-many',
+          targetTable: 'children',
+          fields: ['id'],
+          userLimit: 2,
+        },
+      ],
+      3,
+      0,
+      'parents',
+    );
+
+    expect(receivedParentIds).toEqual([1]);
+    expect(parents[0].children).toHaveLength(1);
+    expect(parents[1].children).toHaveLength(1);
+  });
+
+  test('BatchFetchEngine traces adapter-reported strategy and roundtrips', async () => {
+    const traceEntries: Array<{ stage: string; meta?: Record<string, any> }> =
+      [];
+    const adapter: any = {
+      pkField: 'id',
+      keyOf: (value: any) => String(value),
+      buildScalarRef: (value: any) => ({ id: value }),
+      getTargetPkField: () => 'id',
+      resolveFields: () => ({
+        isPkOnly: false,
+        nestedDescs: [],
+        fetchSpec: { selectCols: ['id'], pkCol: 'id' },
+      }),
+      fetchOwner: async () => [],
+      fetchInverse: async () => ({
+        docs: [],
+        groupKeyField: 'parentId',
+        stats: {
+          strategy: 'partitioned-top-k',
+          roundtrips: 1,
+        },
+      }),
+      fetchM2M: async () => ({ grouped: new Map(), docs: [] }),
+      resolveOwnerFkKey: () => 'ownerId',
+      resolveInverseFkField: () => 'parentId',
+      resolveParentPk: () => 'id',
+    };
+    const metadataGetter = async (table: string) => ({
+      name: table,
+      columns: [{ name: 'id', type: 'integer' }],
+      relations: [],
+    });
+    const engine = new BatchFetchEngine(adapter, metadataGetter, {
+      dur(stage: string, _startTs: number, meta?: Record<string, unknown>) {
+        traceEntries.push({ stage, meta });
+        return 0;
+      },
+    });
+
+    await engine.execute(
+      [{ id: 1 }, { id: 2 }],
+      [
+        {
+          relationName: 'children',
+          type: 'one-to-many',
+          targetTable: 'children',
+          fields: ['id'],
+          userLimit: 2,
+        },
+      ],
+      3,
+      0,
+      'parents',
+    );
+
+    const entry = traceEntries.find((item) => item.stage.includes('children'));
+    expect(entry?.meta?.strategy).toBe('partitioned-top-k');
+    expect(entry?.meta?.roundtrips).toBe(1);
   });
 });

--- a/test/query-builder/deep-filter-sort-limit-mongo.spec.ts
+++ b/test/query-builder/deep-filter-sort-limit-mongo.spec.ts
@@ -2,6 +2,7 @@ import { MongoClient, Db, ObjectId } from 'mongodb';
 import {
   executeMongoBatchFetches,
   getJunctionTableName,
+  MongoQueryExecutor,
   MongoBatchFetchDescriptor,
 } from '@enfyra/kernel';
 
@@ -98,7 +99,8 @@ const metadataGetter = async (table: string) =>
   META[table] ? { ...META[table] } : null;
 
 beforeAll(async () => {
-  client = await MongoClient.connect(MONGO_URI);
+  client = new MongoClient(MONGO_URI, { monitorCommands: true });
+  await client.connect();
   db = client.db(DB_NAME);
 
   await db.collection('users').insertMany([
@@ -399,21 +401,36 @@ describe('deep limit on o2m (Mongo)', () => {
       userLimit: 2,
       userSort: 'seq',
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-    );
+    let aggregateCount = 0;
+    const countAggregate = (event: any) => {
+      if (
+        event.commandName === 'aggregate' &&
+        event.command?.aggregate === 'comments'
+      ) {
+        aggregateCount += 1;
+      }
+    };
+    client.on('commandStarted', countAggregate);
+    try {
+      await executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+      );
+    } finally {
+      client.removeListener('commandStarted', countAggregate);
+    }
 
     expect(rows[0].comments.length).toBe(2);
     expect(rows[1].comments.length).toBe(2);
     expect(rows[2].comments.length).toBe(1);
     expect(rows[0].comments.map((c: any) => c.seq)).toEqual([1, 2]);
+    expect(aggregateCount).toBe(1);
   });
 
   test('limit 1 with sort DESC picks last', async () => {
@@ -545,16 +562,37 @@ describe('deep limit on m2m (Mongo)', () => {
       userLimit: 0,
       userSort: 'priority',
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-    );
+    let relationReadCount = 0;
+    let loadedTargetCount = 0;
+    const countRelationRead = (event: any) => {
+      const collection =
+        event.commandName === 'aggregate'
+          ? event.command?.aggregate
+          : event.commandName === 'find'
+            ? event.command?.find
+            : undefined;
+      if (collection === junctionName || collection === 'tags') {
+        relationReadCount += 1;
+      }
+      if (event.commandName === 'find' && collection === 'tags') {
+        loadedTargetCount = event.command?.filter?._id?.$in?.length ?? 0;
+      }
+    };
+    client.on('commandStarted', countRelationRead);
+    try {
+      await executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+      );
+    } finally {
+      client.removeListener('commandStarted', countRelationRead);
+    }
 
     expect(rows[0].tags.map((tag: any) => tag.label)).toEqual([
       'beta',
@@ -565,6 +603,9 @@ describe('deep limit on m2m (Mongo)', () => {
       'beta',
       'delta',
     ]);
+    expect(rows[0].tags[0]).toBe(rows[1].tags[0]);
+    expect(relationReadCount).toBe(2);
+    expect(loadedTargetCount).toBe(4);
   });
 
   test('limit 2 on tags per post', async () => {
@@ -582,22 +623,46 @@ describe('deep limit on m2m (Mongo)', () => {
       userLimit: 2,
       userSort: 'priority',
     };
-    await executeMongoBatchFetches(
-      db,
-      rows,
-      [desc],
-      metadataGetter,
-      3,
-      0,
-      'posts',
-      metadata,
-    );
+    let relationReadCount = 0;
+    let loadedTargetCount = 0;
+    const countRelationRead = (event: any) => {
+      const collection =
+        event.commandName === 'aggregate'
+          ? event.command?.aggregate
+          : event.commandName === 'find'
+            ? event.command?.find
+            : undefined;
+      if (collection === junctionName || collection === 'tags') {
+        relationReadCount += 1;
+      }
+      if (event.commandName === 'find' && collection === 'tags') {
+        loadedTargetCount = event.command?.filter?._id?.$in?.length ?? 0;
+      }
+    };
+    client.on('commandStarted', countRelationRead);
+    try {
+      await executeMongoBatchFetches(
+        db,
+        rows,
+        [desc],
+        metadataGetter,
+        3,
+        0,
+        'posts',
+        metadata,
+      );
+    } finally {
+      client.removeListener('commandStarted', countRelationRead);
+    }
 
     const post0Tags = rows[0].tags;
     const post1Tags = rows[1].tags;
     expect(post0Tags.map((tag: any) => tag.label)).toEqual(['beta', 'gamma']);
     expect(post1Tags.map((tag: any) => tag.label)).toEqual(['beta', 'delta']);
+    expect(post0Tags[0]).toBe(post1Tags[0]);
     expect(post0Tags[0].priority).toBeUndefined();
+    expect(relationReadCount).toBe(2);
+    expect(loadedTargetCount).toBe(3);
   });
 });
 
@@ -736,7 +801,50 @@ describe('debug trace (Mongo)', () => {
       e.stage.startsWith('batch_fetch_L0_comments'),
     );
     expect(traceEntry).toBeDefined();
-    expect(traceEntry.meta.strategy).toBe('per-parent-c16');
+    expect(traceEntry.meta.strategy).toBe('partitioned-top-k');
+    expect(traceEntry.meta.roundtrips).toBe(1);
     expect(traceEntry.meta.userLimit).toBe(2);
+  });
+
+  test('MongoQueryExecutor propagates debug trace into batch fetches', async () => {
+    const traceEntries: Array<{ stage: string; meta?: Record<string, any> }> =
+      [];
+    const executor = new MongoQueryExecutor({
+      getDb: () => db,
+      collection: (name: string) => db.collection(name),
+    });
+
+    await executor.execute({
+      tableName: 'posts',
+      fields: ['_id'],
+      filter: { _id: { _eq: postIds[0] } },
+      limit: 1,
+      deep: {
+        comments: {
+          fields: ['_id', 'seq'],
+          limit: 2,
+          sort: 'seq',
+        },
+      },
+      metadata,
+      dbType: 'mongodb',
+      debugTrace: {
+        dur(stage: string, _startTs: number, meta?: Record<string, unknown>) {
+          traceEntries.push({ stage, meta });
+          return 0;
+        },
+      },
+    });
+
+    expect(traceEntries.some((entry) => entry.stage === 'db_execute')).toBe(
+      true,
+    );
+    expect(
+      traceEntries.some(
+        (entry) =>
+          entry.stage.includes('batch_fetch') &&
+          entry.meta?.strategy === 'partitioned-top-k',
+      ),
+    ).toBe(true);
   });
 });

--- a/test/query-builder/deep-integration-real-db.spec.ts
+++ b/test/query-builder/deep-integration-real-db.spec.ts
@@ -412,10 +412,14 @@ for (const cfg of DBS) {
       expect(entry!.meta?.rowsTransferred).toBe(1);
     });
 
-    test('debug trace emits per-parent-c16 strategy with roundtrips = parent count', async () => {
+    test('limited o2m uses one partitioned query for multiple parents', async () => {
       if (!available) return;
       const rows = await fetchPosts([1, 2]);
       const trace = new TestTrace();
+      let queryCount = 0;
+      const countQuery = () => {
+        queryCount += 1;
+      };
       const desc: BatchFetchDescriptor = {
         relationName: 'comments',
         type: 'one-to-many',
@@ -427,14 +431,20 @@ for (const cfg of DBS) {
         userLimit: 2,
         userSort: '-seq',
       };
-      await run(rows, [desc], trace);
+      db.on('query', countQuery);
+      try {
+        await run(rows, [desc], trace);
+      } finally {
+        db.removeListener('query', countQuery);
+      }
       const entry = trace.find('comments');
       expect(entry).toBeDefined();
-      expect(entry!.meta?.strategy).toBe('per-parent-c16');
-      expect(entry!.meta?.roundtrips).toBe(2);
+      expect(entry!.meta?.strategy).toBe('partitioned-top-k');
+      expect(entry!.meta?.roundtrips).toBe(1);
+      expect(queryCount).toBe(1);
     });
 
-    test('debug trace emits default to-many limit when limit is omitted', async () => {
+    test('default to-many limit uses one partitioned query', async () => {
       if (!available) return;
       const rows = await fetchPosts([1, 2]);
       const trace = new TestTrace();
@@ -449,9 +459,125 @@ for (const cfg of DBS) {
       };
       await run(rows, [desc], trace);
       const entry = trace.find('comments');
-      expect(entry!.meta?.strategy).toBe('per-parent-c16');
-      expect(entry!.meta?.roundtrips).toBe(2);
+      expect(entry!.meta?.strategy).toBe('partitioned-top-k');
+      expect(entry!.meta?.roundtrips).toBe(1);
       expect(entry!.meta?.userLimit).toBe(10);
+    });
+
+    test('limited m2m selects partitioned edges then batch-loads unique targets', async () => {
+      if (!available) return;
+      const rows = await fetchPosts([1, 2]);
+      const trace = new TestTrace();
+      let queryCount = 0;
+      const countQuery = () => {
+        queryCount += 1;
+      };
+      const desc: BatchFetchDescriptor = {
+        relationName: 'tags',
+        type: 'many-to-many',
+        targetTable: T.tags,
+        fields: ['id', 'label', 'priority'],
+        isInverse: false,
+        junctionTableName: T.junction,
+        junctionSourceColumn: 'postId',
+        junctionTargetColumn: 'tagId',
+        userSort: '-priority',
+        userLimit: 2,
+      };
+
+      db.on('query', countQuery);
+      try {
+        await run(rows, [desc], trace);
+      } finally {
+        db.removeListener('query', countQuery);
+      }
+
+      expect(rows[0].tags.map((tag: any) => tag.label)).toEqual([
+        'alpha',
+        'gamma',
+      ]);
+      expect(rows[1].tags.map((tag: any) => tag.label)).toEqual(['alpha']);
+      expect(rows[0].tags[0]).toBe(rows[1].tags[0]);
+      const entry = trace.find('tags');
+      expect(entry!.meta?.strategy).toBe('m2m-partitioned-edge-loader');
+      expect(entry!.meta?.roundtrips).toBe(2);
+      expect(entry!.meta?.rowsTransferred).toBe(5);
+      expect(queryCount).toBe(2);
+    });
+
+    test('unbounded m2m batch-loads unique targets after junction edges', async () => {
+      if (!available) return;
+      const rows = await fetchPosts([1, 2]);
+      const trace = new TestTrace();
+      let queryCount = 0;
+      const countQuery = () => {
+        queryCount += 1;
+      };
+      const desc: BatchFetchDescriptor = {
+        relationName: 'tags',
+        type: 'many-to-many',
+        targetTable: T.tags,
+        fields: ['id', 'label', 'priority'],
+        isInverse: false,
+        junctionTableName: T.junction,
+        junctionSourceColumn: 'postId',
+        junctionTargetColumn: 'tagId',
+        userSort: 'priority',
+        userLimit: 0,
+      };
+
+      db.on('query', countQuery);
+      try {
+        await run(rows, [desc], trace);
+      } finally {
+        db.removeListener('query', countQuery);
+      }
+
+      expect(rows[0].tags.map((tag: any) => tag.label)).toEqual([
+        'beta',
+        'gamma',
+        'alpha',
+      ]);
+      expect(rows[1].tags.map((tag: any) => tag.label)).toEqual(['alpha']);
+      expect(rows[0].tags[2]).toBe(rows[1].tags[0]);
+      const entry = trace.find('tags');
+      expect(entry!.meta?.strategy).toBe('m2m-edge-loader');
+      expect(entry!.meta?.roundtrips).toBe(2);
+      expect(entry!.meta?.rowsTransferred).toBe(7);
+      expect(queryCount).toBe(2);
+    });
+
+    test('m2m target-id sort selects edges without joining target rows', async () => {
+      if (!available) return;
+      const rows = await fetchPosts([1, 2]);
+      const statements: string[] = [];
+      const collectQuery = (query: { sql: string }) => {
+        statements.push(query.sql);
+      };
+      const desc: BatchFetchDescriptor = {
+        relationName: 'tags',
+        type: 'many-to-many',
+        targetTable: T.tags,
+        fields: ['id', 'label'],
+        isInverse: false,
+        junctionTableName: T.junction,
+        junctionSourceColumn: 'postId',
+        junctionTargetColumn: 'tagId',
+        userSort: '-id',
+        userLimit: 2,
+      };
+
+      db.on('query', collectQuery);
+      try {
+        await run(rows, [desc]);
+      } finally {
+        db.removeListener('query', collectQuery);
+      }
+
+      expect(rows[0].tags.map((tag: any) => tag.id)).toEqual([3, 2]);
+      expect(rows[1].tags.map((tag: any) => tag.id)).toEqual([1]);
+      expect(statements).toHaveLength(2);
+      expect(statements[0].toLowerCase()).not.toContain(' join ');
     });
   });
 }

--- a/test/query-builder/m2m-loader-matrix-real-db.spec.ts
+++ b/test/query-builder/m2m-loader-matrix-real-db.spec.ts
@@ -1,0 +1,844 @@
+import knex, { type Knex } from 'knex';
+import { type Db, MongoClient } from 'mongodb';
+import {
+  executeBatchFetches,
+  executeMongoBatchFetches,
+  type BatchFetchDescriptor,
+  type BatchTrace,
+} from '@enfyra/kernel';
+
+type ProjectionVariant = 'pk' | 'full';
+type FilterVariant = 'none' | 'active' | 'score' | 'combined' | 'empty';
+type SortVariant =
+  | 'default'
+  | 'id-asc'
+  | 'id-desc'
+  | 'score-asc'
+  | 'score-desc'
+  | 'score-desc-id-desc';
+
+interface MatrixCase {
+  name: string;
+  projection: ProjectionVariant;
+  filter: FilterVariant;
+  sort: SortVariant;
+  userLimit?: number;
+  userPage?: number;
+}
+
+interface TargetRow {
+  id: number;
+  label: string;
+  score: number;
+  active: boolean;
+}
+
+interface MatrixHarness {
+  pkField: 'id' | '_id';
+  makeParents(ids: number[]): any[];
+  run(
+    parents: any[],
+    descriptor: BatchFetchDescriptor,
+    trace: MatrixTrace,
+  ): Promise<void>;
+  countQueries(task: () => Promise<void>): Promise<number>;
+  measureQueryConcurrency(
+    task: () => Promise<void>,
+  ): Promise<{ count: number; maxActive: number }>;
+}
+
+interface ExpectedCase {
+  byParent: Map<number, TargetRow[]>;
+  edgeCount: number;
+  uniqueTargetCount: number;
+}
+
+const PARENT_IDS = [1, 2, 3, 4, 5, 6];
+const TARGETS: TargetRow[] = Array.from({ length: 30 }, (_, index) => {
+  const id = index + 1;
+  return {
+    id,
+    label: `target-${id}`,
+    score: id % 5,
+    active: id % 2 === 0,
+  };
+});
+const TARGET_BY_ID = new Map(TARGETS.map((target) => [target.id, target]));
+const EDGE_IDS = new Map<number, number[]>([
+  [1, Array.from({ length: 15 }, (_, index) => index + 1)],
+  [2, [1, 2, 3, ...Array.from({ length: 10 }, (_, index) => index + 16)]],
+  [3, []],
+  [4, [30, 29, 28, 27]],
+  [5, [5, 10, 15, 20, 25, 30]],
+  [6, Array.from({ length: 30 }, (_, index) => index + 1)],
+]);
+
+const PAGINATION_VARIANTS = [
+  { name: 'default-limit' },
+  { name: 'unbounded', userLimit: 0 },
+  { name: 'limit-1-page-1', userLimit: 1, userPage: 1 },
+  { name: 'limit-1-page-2', userLimit: 1, userPage: 2 },
+  { name: 'limit-3-page-1', userLimit: 3, userPage: 1 },
+  { name: 'limit-3-page-2', userLimit: 3, userPage: 2 },
+  { name: 'limit-3-page-99', userLimit: 3, userPage: 99 },
+] as const;
+const SORT_VARIANTS: SortVariant[] = [
+  'default',
+  'id-asc',
+  'id-desc',
+  'score-asc',
+  'score-desc',
+  'score-desc-id-desc',
+];
+const FILTER_VARIANTS: FilterVariant[] = [
+  'none',
+  'active',
+  'score',
+  'combined',
+  'empty',
+];
+const PROJECTION_VARIANTS: ProjectionVariant[] = ['pk', 'full'];
+const MATRIX_CASES: MatrixCase[] = PAGINATION_VARIANTS.flatMap((pagination) =>
+  SORT_VARIANTS.flatMap((sort) =>
+    FILTER_VARIANTS.flatMap((filter) =>
+      PROJECTION_VARIANTS.map((projection) => ({
+        name: [pagination.name, sort, filter, projection].join(' | '),
+        projection,
+        filter,
+        sort,
+        userLimit: 'userLimit' in pagination ? pagination.userLimit : undefined,
+        userPage: 'userPage' in pagination ? pagination.userPage : undefined,
+      })),
+    ),
+  ),
+);
+
+class MatrixTrace implements BatchTrace {
+  entries: Array<{
+    stage: string;
+    meta?: Record<string, unknown>;
+  }> = [];
+
+  dur(stage: string, _startTs: number, meta?: Record<string, unknown>): number {
+    this.entries.push({ stage, meta });
+    return 0;
+  }
+
+  relation() {
+    return this.entries.find((entry) =>
+      entry.stage.includes('batch_fetch_L0_targets'),
+    );
+  }
+}
+
+function descriptorFor(
+  matrixCase: MatrixCase,
+  targetTable: string,
+  junctionTable: string,
+  sourceColumn: string,
+  targetColumn: string,
+  pkField: 'id' | '_id',
+): BatchFetchDescriptor {
+  const filters: Record<FilterVariant, Record<string, unknown> | undefined> = {
+    none: undefined,
+    active: { active: { _eq: true } },
+    score: { score: { _gte: 3 } },
+    combined: {
+      _and: [{ active: { _eq: true } }, { score: { _gte: 3 } }],
+    },
+    empty: { score: { _gt: 999 } },
+  };
+  const sorts: Record<SortVariant, string | string[] | undefined> = {
+    default: undefined,
+    'id-asc': 'id',
+    'id-desc': '-id',
+    'score-asc': 'score',
+    'score-desc': '-score',
+    'score-desc-id-desc': ['-score', '-id'],
+  };
+
+  return {
+    relationName: 'targets',
+    type: 'many-to-many',
+    targetTable,
+    fields:
+      matrixCase.projection === 'pk'
+        ? [pkField]
+        : [pkField, 'label', 'score', 'active'],
+    isInverse: false,
+    junctionTableName: junctionTable,
+    junctionSourceColumn: sourceColumn,
+    junctionTargetColumn: targetColumn,
+    userFilter: filters[matrixCase.filter],
+    userSort: sorts[matrixCase.sort],
+    userLimit: matrixCase.userLimit,
+    userPage: matrixCase.userPage,
+  };
+}
+
+function filterTarget(target: TargetRow, filter: FilterVariant): boolean {
+  if (filter === 'active') return target.active;
+  if (filter === 'score') return target.score >= 3;
+  if (filter === 'combined') return target.active && target.score >= 3;
+  if (filter === 'empty') return target.score > 999;
+  return true;
+}
+
+function compareTargets(
+  left: TargetRow,
+  right: TargetRow,
+  sort: SortVariant,
+): number {
+  if (sort === 'id-desc') return right.id - left.id;
+  if (sort === 'score-asc') {
+    return left.score - right.score || left.id - right.id;
+  }
+  if (sort === 'score-desc') {
+    return right.score - left.score || left.id - right.id;
+  }
+  if (sort === 'score-desc-id-desc') {
+    return right.score - left.score || right.id - left.id;
+  }
+  return left.id - right.id;
+}
+
+function expectedCase(
+  matrixCase: MatrixCase,
+  parentIds: number[] = PARENT_IDS,
+): ExpectedCase {
+  const byParent = new Map<number, TargetRow[]>();
+  const selectedIds = new Set<number>();
+  let edgeCount = 0;
+  const effectiveLimit =
+    matrixCase.userLimit === undefined ? 10 : matrixCase.userLimit;
+  const offset =
+    effectiveLimit > 0 ? ((matrixCase.userPage ?? 1) - 1) * effectiveLimit : 0;
+
+  for (const parentId of new Set(parentIds)) {
+    const targets = (EDGE_IDS.get(parentId) ?? [])
+      .map((targetId) => TARGET_BY_ID.get(targetId)!)
+      .filter((target) => filterTarget(target, matrixCase.filter))
+      .sort((left, right) => compareTargets(left, right, matrixCase.sort));
+    const selected =
+      effectiveLimit > 0
+        ? targets.slice(offset, offset + effectiveLimit)
+        : targets;
+    byParent.set(parentId, selected);
+    edgeCount += selected.length;
+    for (const target of selected) selectedIds.add(target.id);
+  }
+
+  return {
+    byParent,
+    edgeCount,
+    uniqueTargetCount: selectedIds.size,
+  };
+}
+
+function normalizeTarget(
+  target: any,
+  pkField: 'id' | '_id',
+  projection: ProjectionVariant,
+): Record<string, unknown> {
+  if (projection === 'pk') {
+    return { id: target[pkField] };
+  }
+  return {
+    id: target[pkField],
+    label: target.label,
+    score: target.score,
+    active: Boolean(target.active),
+  };
+}
+
+function expectedTarget(
+  target: TargetRow,
+  projection: ProjectionVariant,
+): Record<string, unknown> {
+  if (projection === 'pk') return { id: target.id };
+  return { ...target };
+}
+
+function assertResult(
+  parents: any[],
+  harness: MatrixHarness,
+  matrixCase: MatrixCase,
+  expected: ExpectedCase,
+): void {
+  const refsByTarget = new Map<number, any>();
+  const expectedKeys =
+    matrixCase.projection === 'pk'
+      ? [harness.pkField]
+      : [harness.pkField, 'active', 'label', 'score'].sort();
+
+  for (const parent of parents) {
+    const parentId = parent[harness.pkField];
+    const actualTargets = parent.targets;
+    expect(
+      actualTargets.map((target: any) =>
+        normalizeTarget(target, harness.pkField, matrixCase.projection),
+      ),
+    ).toStrictEqual(
+      (expected.byParent.get(parentId) ?? []).map((target) =>
+        expectedTarget(target, matrixCase.projection),
+      ),
+    );
+    for (const target of actualTargets) {
+      expect(Object.keys(target).sort()).toStrictEqual(expectedKeys);
+      const targetId = target[harness.pkField];
+      const previous = refsByTarget.get(targetId);
+      if (previous) {
+        expect(target).toBe(previous);
+      } else {
+        refsByTarget.set(targetId, target);
+      }
+    }
+  }
+}
+
+function expectedStrategy(matrixCase: MatrixCase): string {
+  const limited =
+    matrixCase.userLimit === undefined || matrixCase.userLimit > 0;
+  if (matrixCase.projection === 'full') {
+    return limited ? 'm2m-partitioned-edge-loader' : 'm2m-edge-loader';
+  }
+  const junctionOnly =
+    matrixCase.filter === 'none' &&
+    ['default', 'id-asc', 'id-desc'].includes(matrixCase.sort);
+  if (junctionOnly) {
+    return limited ? 'm2m-junction-partitioned-top-k' : 'm2m-junction-batch';
+  }
+  return limited ? 'm2m-filtered-edge-top-k' : 'm2m-filtered-edge-batch';
+}
+
+async function executeMatrixCase(
+  harness: MatrixHarness,
+  matrixCase: MatrixCase,
+  descriptor: BatchFetchDescriptor,
+): Promise<void> {
+  const parents = harness.makeParents(PARENT_IDS);
+  const trace = new MatrixTrace();
+  const expected = expectedCase(matrixCase);
+  const queryCount = await harness.countQueries(() =>
+    harness.run(parents, descriptor, trace),
+  );
+  const expectedQueries =
+    matrixCase.projection === 'pk' || expected.uniqueTargetCount === 0 ? 1 : 2;
+  const relationTrace = trace.relation();
+
+  assertResult(parents, harness, matrixCase, expected);
+  expect(queryCount).toBe(expectedQueries);
+  expect(relationTrace).toBeDefined();
+  expect(relationTrace!.meta).toMatchObject({
+    strategy: expectedStrategy(matrixCase),
+    roundtrips: expectedQueries,
+    ioConcurrency: 2,
+    rowsTransferred:
+      expected.edgeCount +
+      (matrixCase.projection === 'full' ? expected.uniqueTargetCount : 0),
+    rowsReturned: expected.edgeCount,
+    rowsDiscarded: 0,
+    userLimit: matrixCase.userLimit === undefined ? 10 : matrixCase.userLimit,
+    userFilter: matrixCase.filter !== 'none',
+    userSort: matrixCase.sort !== 'default',
+  });
+}
+
+function registerInvariantTests(
+  harness: () => MatrixHarness,
+  descriptor: () => BatchFetchDescriptor,
+): void {
+  test('deduplicates parent ids and shares relation arrays and target objects', async () => {
+    const activeHarness = harness();
+    const parents = activeHarness.makeParents([1, 1, 2]);
+    const trace = new MatrixTrace();
+    const queries = await activeHarness.countQueries(() =>
+      activeHarness.run(parents, descriptor(), trace),
+    );
+
+    expect(queries).toBe(2);
+    expect(parents[0].targets).toBe(parents[1].targets);
+    expect(parents[0].targets[0]).toBe(parents[2].targets[0]);
+    expect(trace.relation()!.meta).toMatchObject({
+      roundtrips: 2,
+      rowsReturned: 2,
+      rowsTransferred: 3,
+      rowsDiscarded: 0,
+    });
+  });
+
+  test('does no metadata lookup or database query for empty parent input', async () => {
+    const activeHarness = harness();
+    const trace = new MatrixTrace();
+    const queries = await activeHarness.countQueries(() =>
+      activeHarness.run([], descriptor(), trace),
+    );
+
+    expect(queries).toBe(0);
+    expect(trace.entries).toStrictEqual([]);
+  });
+
+  test('chunks 5001 parent ids into two edge queries and one target query', async () => {
+    const activeHarness = harness();
+    const parents = activeHarness.makeParents(
+      Array.from({ length: 5001 }, (_, index) => index + 1),
+    );
+    const trace = new MatrixTrace();
+    const metrics = await activeHarness.measureQueryConcurrency(() =>
+      activeHarness.run(parents, descriptor(), trace),
+    );
+
+    expect(metrics.count).toBe(3);
+    expect(metrics.maxActive).toBeGreaterThanOrEqual(1);
+    expect(metrics.maxActive).toBeLessThanOrEqual(2);
+    expect(parents[2].targets).toStrictEqual([]);
+    expect(parents[5000].targets).toStrictEqual([]);
+    expect(trace.relation()!.meta).toMatchObject({
+      strategy: 'm2m-partitioned-edge-loader',
+      roundtrips: 3,
+      ioConcurrency: 2,
+      rowsTransferred: 8,
+      rowsReturned: 5,
+      rowsDiscarded: 0,
+    });
+  });
+
+  test('rejects an unknown local sort before mutating parent documents', async () => {
+    const activeHarness = harness();
+    const parents = activeHarness.makeParents([1, 2]);
+    const trace = new MatrixTrace();
+    const invalidDescriptor = {
+      ...descriptor(),
+      userSort: 'missingField',
+    };
+
+    await expect(
+      activeHarness.run(parents, invalidDescriptor, trace),
+    ).rejects.toThrow("Sort field 'missingField' does not exist");
+    expect(parents.every((parent) => !('targets' in parent))).toBe(true);
+    expect(trace.entries).toStrictEqual([]);
+  });
+
+  test('rejects missing target metadata without partial assignment', async () => {
+    const activeHarness = harness();
+    const parents = activeHarness.makeParents([1, 2]);
+    const trace = new MatrixTrace();
+    const invalidDescriptor = {
+      ...descriptor(),
+      targetTable: '__missing_m2m_matrix_target__',
+    };
+
+    await expect(
+      activeHarness.run(parents, invalidDescriptor, trace),
+    ).rejects.toThrow('Metadata not found for target table');
+    expect(parents.every((parent) => !('targets' in parent))).toBe(true);
+    expect(trace.entries).toStrictEqual([]);
+  });
+}
+
+const SQL_CONFIGS = [
+  {
+    name: 'postgres',
+    client: 'pg',
+    connection:
+      process.env.PG_TEST_URI ||
+      'postgresql://root:1234@localhost:5432/postgres',
+    dbType: 'postgres' as const,
+  },
+  {
+    name: 'mysql',
+    client: 'mysql2',
+    connection:
+      process.env.MYSQL_TEST_URI || 'mysql://root:1234@localhost:3306/enfyra',
+    dbType: 'mysql' as const,
+  },
+];
+
+for (const config of SQL_CONFIGS) {
+  describe.sequential(`m2m loader matrix (${config.name})`, () => {
+    const prefix = `__m2m_mx_${Date.now()}_${config.name}_`;
+    const tables = {
+      parents: `${prefix}parents`,
+      targets: `${prefix}targets`,
+      junction: `${prefix}junction`,
+    };
+    const metadata: Record<string, any> = {
+      [tables.parents]: {
+        name: tables.parents,
+        columns: [{ name: 'id', type: 'integer', isPrimary: true }],
+        relations: [
+          {
+            propertyName: 'targets',
+            type: 'many-to-many',
+            targetTableName: tables.targets,
+            targetTable: tables.targets,
+            isInverse: false,
+            junctionTableName: tables.junction,
+            junctionSourceColumn: 'parentId',
+            junctionTargetColumn: 'targetId',
+          },
+        ],
+      },
+      [tables.targets]: {
+        name: tables.targets,
+        columns: [
+          { name: 'id', type: 'integer', isPrimary: true },
+          { name: 'label', type: 'varchar' },
+          { name: 'score', type: 'integer' },
+          { name: 'active', type: 'boolean' },
+        ],
+        relations: [],
+      },
+    };
+    let db: Knex;
+    let available = true;
+    let harness: MatrixHarness;
+
+    beforeAll(async () => {
+      db = knex({
+        client: config.client,
+        connection: config.connection,
+        pool: { min: 0, max: 4 },
+      });
+      try {
+        await db.raw('SELECT 1');
+      } catch {
+        available = false;
+        return;
+      }
+
+      await db.schema.dropTableIfExists(tables.junction);
+      await db.schema.dropTableIfExists(tables.targets);
+      await db.schema.dropTableIfExists(tables.parents);
+      await db.schema.createTable(tables.parents, (table) => {
+        table.integer('id').primary();
+      });
+      await db.schema.createTable(tables.targets, (table) => {
+        table.integer('id').primary();
+        table.string('label').notNullable();
+        table.integer('score').notNullable();
+        table.boolean('active').notNullable();
+      });
+      await db.schema.createTable(tables.junction, (table) => {
+        table.integer('parentId').notNullable().index();
+        table.integer('targetId').notNullable().index();
+        table.unique(['parentId', 'targetId']);
+      });
+      await db(tables.parents).insert(PARENT_IDS.map((id) => ({ id })));
+      await db(tables.targets).insert(TARGETS);
+      await db(tables.junction).insert(
+        Array.from(EDGE_IDS.entries()).flatMap(([parentId, targetIds]) =>
+          targetIds.map((targetId) => ({ parentId, targetId })),
+        ),
+      );
+
+      harness = {
+        pkField: 'id',
+        makeParents: (ids) => ids.map((id) => ({ id })),
+        run: async (parents, descriptor, trace) => {
+          await executeBatchFetches(
+            db,
+            parents,
+            [descriptor],
+            async (table) => metadata[table] ?? null,
+            3,
+            0,
+            tables.parents,
+            config.dbType,
+            metadata,
+            trace,
+          );
+        },
+        countQueries: async (task) => {
+          let count = 0;
+          const listener = () => {
+            count += 1;
+          };
+          db.on('query', listener);
+          try {
+            await task();
+          } finally {
+            db.removeListener('query', listener);
+          }
+          return count;
+        },
+        measureQueryConcurrency: async (task) => {
+          let count = 0;
+          let maxActive = 0;
+          const active = new Set<string>();
+          const onQuery = (query: { __knexQueryUid?: string }) => {
+            const id = query.__knexQueryUid ?? `query-${count}`;
+            count += 1;
+            active.add(id);
+            maxActive = Math.max(maxActive, active.size);
+          };
+          const onComplete = (
+            _result: unknown,
+            query: { __knexQueryUid?: string },
+          ) => {
+            if (query?.__knexQueryUid) active.delete(query.__knexQueryUid);
+          };
+          const onError = (
+            _error: unknown,
+            query: { __knexQueryUid?: string },
+          ) => {
+            if (query?.__knexQueryUid) active.delete(query.__knexQueryUid);
+          };
+          db.on('query', onQuery);
+          db.on('query-response', onComplete);
+          db.on('query-error', onError);
+          try {
+            await task();
+          } finally {
+            db.removeListener('query', onQuery);
+            db.removeListener('query-response', onComplete);
+            db.removeListener('query-error', onError);
+          }
+          return { count, maxActive };
+        },
+      };
+    }, 30_000);
+
+    afterAll(async () => {
+      if (!db) return;
+      if (available) {
+        await db.schema.dropTableIfExists(tables.junction);
+        await db.schema.dropTableIfExists(tables.targets);
+        await db.schema.dropTableIfExists(tables.parents);
+      }
+      await db.destroy();
+    }, 30_000);
+
+    test.each(MATRIX_CASES)('$name', async (matrixCase) => {
+      if (!available) return;
+      await executeMatrixCase(
+        harness,
+        matrixCase,
+        descriptorFor(
+          matrixCase,
+          tables.targets,
+          tables.junction,
+          'parentId',
+          'targetId',
+          'id',
+        ),
+      );
+    });
+
+    registerInvariantTests(
+      () => harness,
+      () =>
+        descriptorFor(
+          {
+            name: 'invariant',
+            projection: 'full',
+            filter: 'none',
+            sort: 'id-asc',
+            userLimit: 1,
+            userPage: 1,
+          },
+          tables.targets,
+          tables.junction,
+          'parentId',
+          'targetId',
+          'id',
+        ),
+    );
+  });
+}
+
+describe.sequential('m2m loader matrix (mongodb)', () => {
+  const databaseName = `m2m_matrix_${Date.now()}`;
+  const collections = {
+    parents: 'parents',
+    targets: 'targets',
+    junction: 'parents_targets',
+  };
+  const metadata: Record<string, any> = {
+    [collections.parents]: {
+      name: collections.parents,
+      columns: [{ name: '_id', type: 'integer', isPrimary: true }],
+      relations: [
+        {
+          propertyName: 'targets',
+          type: 'many-to-many',
+          targetTableName: collections.targets,
+          targetTable: collections.targets,
+          isInverse: false,
+          junctionTableName: collections.junction,
+          junctionSourceColumn: 'sourceId',
+          junctionTargetColumn: 'targetId',
+        },
+      ],
+    },
+    [collections.targets]: {
+      name: collections.targets,
+      columns: [
+        { name: '_id', type: 'integer', isPrimary: true },
+        { name: 'label', type: 'varchar' },
+        { name: 'score', type: 'integer' },
+        { name: 'active', type: 'boolean' },
+      ],
+      relations: [],
+    },
+  };
+  let client: MongoClient;
+  let db: Db;
+  let available = true;
+  let harness: MatrixHarness;
+
+  beforeAll(async () => {
+    client = new MongoClient(
+      process.env.MONGO_TEST_URI ||
+        'mongodb://enfyra_admin:enfyra_password_123@localhost:27017/?authSource=admin',
+      { monitorCommands: true },
+    );
+    try {
+      await client.connect();
+    } catch {
+      available = false;
+      return;
+    }
+    db = client.db(databaseName);
+    await db
+      .collection(collections.parents)
+      .insertMany(PARENT_IDS.map((id) => ({ _id: id })));
+    await db
+      .collection(collections.targets)
+      .insertMany(TARGETS.map(({ id, ...target }) => ({ _id: id, ...target })));
+    await db
+      .collection(collections.junction)
+      .insertMany(
+        Array.from(EDGE_IDS.entries()).flatMap(([sourceId, targetIds]) =>
+          targetIds.map((targetId) => ({ sourceId, targetId })),
+        ),
+      );
+    await db
+      .collection(collections.junction)
+      .createIndex({ sourceId: 1, targetId: 1 }, { unique: true });
+
+    harness = {
+      pkField: '_id',
+      makeParents: (ids) => ids.map((_id) => ({ _id })),
+      run: async (parents, descriptor, trace) => {
+        await executeMongoBatchFetches(
+          db,
+          parents,
+          [descriptor],
+          async (table) => metadata[table] ?? null,
+          3,
+          0,
+          collections.parents,
+          { tables: new Map(Object.entries(metadata)) },
+          trace,
+        );
+      },
+      countQueries: async (task) => {
+        let count = 0;
+        const listener = (event: {
+          databaseName: string;
+          commandName: string;
+          command: Record<string, unknown>;
+        }) => {
+          if (event.databaseName !== databaseName) return;
+          const collection = event.command[event.commandName];
+          if (
+            ['find', 'aggregate'].includes(event.commandName) &&
+            [collections.junction, collections.targets].includes(
+              String(collection),
+            )
+          ) {
+            count += 1;
+          }
+        };
+        client.on('commandStarted', listener);
+        try {
+          await task();
+        } finally {
+          client.removeListener('commandStarted', listener);
+        }
+        return count;
+      },
+      measureQueryConcurrency: async (task) => {
+        let count = 0;
+        let maxActive = 0;
+        const active = new Set<number>();
+        const onStarted = (event: {
+          requestId: number;
+          databaseName: string;
+          commandName: string;
+          command: Record<string, unknown>;
+        }) => {
+          if (event.databaseName !== databaseName) return;
+          const collection = event.command[event.commandName];
+          if (
+            !['find', 'aggregate'].includes(event.commandName) ||
+            ![collections.junction, collections.targets].includes(
+              String(collection),
+            )
+          ) {
+            return;
+          }
+          count += 1;
+          active.add(event.requestId);
+          maxActive = Math.max(maxActive, active.size);
+        };
+        const onComplete = (event: { requestId: number }) => {
+          active.delete(event.requestId);
+        };
+        client.on('commandStarted', onStarted);
+        client.on('commandSucceeded', onComplete);
+        client.on('commandFailed', onComplete);
+        try {
+          await task();
+        } finally {
+          client.removeListener('commandStarted', onStarted);
+          client.removeListener('commandSucceeded', onComplete);
+          client.removeListener('commandFailed', onComplete);
+        }
+        return { count, maxActive };
+      },
+    };
+  }, 30_000);
+
+  afterAll(async () => {
+    if (available && db) await db.dropDatabase();
+    if (client) await client.close();
+  }, 30_000);
+
+  test.each(MATRIX_CASES)('$name', async (matrixCase) => {
+    if (!available) return;
+    await executeMatrixCase(
+      harness,
+      matrixCase,
+      descriptorFor(
+        matrixCase,
+        collections.targets,
+        collections.junction,
+        'sourceId',
+        'targetId',
+        '_id',
+      ),
+    );
+  });
+
+  registerInvariantTests(
+    () => harness,
+    () =>
+      descriptorFor(
+        {
+          name: 'invariant',
+          projection: 'full',
+          filter: 'none',
+          sort: 'id-asc',
+          userLimit: 1,
+          userPage: 1,
+        },
+        collections.targets,
+        collections.junction,
+        'sourceId',
+        'targetId',
+        '_id',
+      ),
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,16 +449,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@enfyra/kernel@npm:1.1.30":
-  version: 1.1.30
-  resolution: "@enfyra/kernel@npm:1.1.30"
+"@enfyra/kernel@npm:1.1.31":
+  version: 1.1.31
+  resolution: "@enfyra/kernel@npm:1.1.31"
   dependencies:
     "@types/node": "npm:^24.12.2"
     isolated-vm: "npm:^6.1.2"
     knex: "npm:^3.2.9"
     mongodb: "npm:^7.1.1"
     typescript: "npm:^5.1.3"
-  checksum: 10c0/47087632f0ee2f7a7d141746f9f5d19641a8c0fc181f3cb8ea85b3deff46ca760d23ce41b7be99ba3ab4f2e77c3e8e1b67da404e77a108fb24c821938de1d4e8
+  checksum: 10c0/24751c00338959a401f2dbb6e772a279a242a5a01e99055d9a4d6a3c840ca6c92148a44b90b43348c8fc9db5cbfc4ebe088f0365271b50f88434dfa6a0fb260b
   languageName: node
   linkType: hard
 
@@ -3316,7 +3316,7 @@ __metadata:
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.1024.0"
     "@aws-sdk/lib-storage": "npm:3.1024.0"
-    "@enfyra/kernel": "npm:1.1.30"
+    "@enfyra/kernel": "npm:1.1.31"
     "@envelop/core": "npm:^5.5.1"
     "@envelop/depth-limit": "npm:^7.1.1"
     "@eslint/eslintrc": "npm:^3.3.5"


### PR DESCRIPTION
…t for M2M data loader

- Updated the version of @enfyra/kernel in yarn.lock from 1.1.30 to 1.1.31.
- Introduced a new benchmark script (benchmark-m2m-dataloader-pg.mjs) to evaluate the performance of the M2M data loader with PostgreSQL.
- Added comprehensive tests for the M2M loader matrix, covering various pagination, sorting, and filtering scenarios in both PostgreSQL and MongoDB environments.