### PR TITLE
Release v2.2.15-patch-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.2.15-patch-1",
+  "version": "2.2.15-patch-2",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "license": "Elastic-2.0",

--- a/src/modules/dynamic-api/repositories/dynamic.repository.ts
+++ b/src/modules/dynamic-api/repositories/dynamic.repository.ts
@@ -334,6 +334,41 @@ export class DynamicRepository {
     return stripped;
   }
 
+  private stripUnpublishedEmptyFields(data: any, tableMetadata: any): any {
+    if (!data || typeof data !== 'object' || !tableMetadata?.columns) {
+      return data;
+    }
+
+    const stripped = { ...data };
+    for (const column of tableMetadata.columns) {
+      if (column.isPublished === false && column.name in stripped) {
+        const value = stripped[column.name];
+        const isStringLike = [
+          'varchar',
+          'text',
+          'uuid',
+          'ObjectId',
+          'enum',
+          'simple-json',
+          'code',
+          'array-select',
+          'richtext',
+          'date',
+          'datetime',
+          'timestamp',
+        ].includes(column.type);
+        const isEmpty =
+          value === null ||
+          value === undefined ||
+          (isStringLike && value === '');
+        if (isEmpty) {
+          delete stripped[column.name];
+        }
+      }
+    }
+    return stripped;
+  }
+
   private async assertQueryAllowed() {
     if (!this.enforceFieldPermission) return;
     if (this.context?.$user?.isRootAdmin) return;
@@ -1161,10 +1196,8 @@ export class DynamicRepository {
     try {
       const { id, fields } = opt;
       const originalBody = opt.data;
-      const body = this.stripNonUpdatableColumns(
-        originalBody,
-        this.tableMetadata,
-      );
+      let body = this.stripNonUpdatableColumns(originalBody, this.tableMetadata);
+      body = this.stripUnpublishedEmptyFields(body, this.tableMetadata);
       logMemory(this.logger, 'dynamic update body stripped', {
         ...writeMeta,
         bodyKeys:

--- a/test/modules/dynamic-repository-route-methods.spec.ts
+++ b/test/modules/dynamic-repository-route-methods.spec.ts
@@ -87,6 +87,168 @@ describe('DynamicRepository route method relations', () => {
     });
   });
 
+  it('strips empty unpublished fields from update payloads', async () => {
+    const queryBuilderService = {
+      getPkField: vi.fn(() => '_id'),
+      find: vi.fn().mockResolvedValue({
+        data: [
+          {
+            _id: 'row-1',
+            name: 'existing name',
+            secret: 'keep-me',
+          },
+        ],
+        count: 1,
+      }),
+      update: vi.fn().mockResolvedValue({}),
+      runWithPolicy: vi.fn().mockImplementation(async (_policy: any, fn: any) => fn()),
+    };
+    const repo = makeRepo({
+      queryBuilderService: queryBuilderService as any,
+      tableValidationService: {
+        assertTableValid: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      policyService: {
+        checkMutationSafety: vi.fn().mockResolvedValue({ allowed: true }),
+      } as any,
+    });
+    vi.spyOn(repo as any, 'ensureInit').mockResolvedValue(undefined);
+    vi.spyOn(repo as any, 'reload').mockResolvedValue(undefined);
+    vi.spyOn(repo as any, 'emitTableMutation').mockImplementation(() => {});
+    (repo as any).tableMetadata = {
+      columns: [
+        { name: '_id', isPrimary: true },
+        { name: 'name', isPublished: true },
+        { name: 'secret', isPublished: false },
+      ],
+    };
+
+    await repo.update({
+      id: 'row-1',
+      data: {
+        name: 'updated name',
+        secret: null,
+      },
+    });
+
+    expect(queryBuilderService.update).toHaveBeenCalledWith(
+      'enfyra_route',
+      'row-1',
+      expect.objectContaining({
+        name: 'updated name',
+      }),
+    );
+    expect(queryBuilderService.update.mock.calls[0][2]).not.toHaveProperty(
+      'secret',
+    );
+  });
+
+  it('keeps non-empty unpublished field values on update', async () => {
+    const queryBuilderService = {
+      getPkField: vi.fn(() => '_id'),
+      find: vi.fn().mockResolvedValue({
+        data: [{ _id: 'row-1', name: 'existing', secret: 'old' }],
+        count: 1,
+      }),
+      update: vi.fn().mockResolvedValue({}),
+      runWithPolicy: vi.fn().mockImplementation(async (_policy: any, fn: any) => fn()),
+    };
+    const repo = makeRepo({
+      queryBuilderService: queryBuilderService as any,
+      tableValidationService: {
+        assertTableValid: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      policyService: {
+        checkMutationSafety: vi.fn().mockResolvedValue({ allowed: true }),
+      } as any,
+    });
+    vi.spyOn(repo as any, 'ensureInit').mockResolvedValue(undefined);
+    vi.spyOn(repo as any, 'reload').mockResolvedValue(undefined);
+    vi.spyOn(repo as any, 'emitTableMutation').mockImplementation(() => {});
+    (repo as any).tableMetadata = {
+      columns: [
+        { name: '_id', isPrimary: true },
+        { name: 'name', isPublished: true },
+        { name: 'secret', isPublished: false },
+      ],
+    };
+
+    await repo.update({
+      id: 'row-1',
+      data: {
+        name: 'updated name',
+        secret: 'real-value',
+      },
+    });
+
+    expect(queryBuilderService.update).toHaveBeenCalledWith(
+      'enfyra_route',
+      'row-1',
+      expect.objectContaining({
+        name: 'updated name',
+        secret: 'real-value',
+      }),
+    );
+  });
+
+  it('keeps boolean false and numeric zero for unpublished fields', async () => {
+    const queryBuilderService = {
+      getPkField: vi.fn(() => '_id'),
+      find: vi.fn().mockResolvedValue({
+        data: [
+          {
+            _id: 'row-1',
+            name: 'existing',
+            active: true,
+            score: 5,
+          },
+        ],
+        count: 1,
+      }),
+      update: vi.fn().mockResolvedValue({}),
+      runWithPolicy: vi.fn().mockImplementation(async (_policy: any, fn: any) => fn()),
+    };
+    const repo = makeRepo({
+      queryBuilderService: queryBuilderService as any,
+      tableValidationService: {
+        assertTableValid: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      policyService: {
+        checkMutationSafety: vi.fn().mockResolvedValue({ allowed: true }),
+      } as any,
+    });
+    vi.spyOn(repo as any, 'ensureInit').mockResolvedValue(undefined);
+    vi.spyOn(repo as any, 'reload').mockResolvedValue(undefined);
+    vi.spyOn(repo as any, 'emitTableMutation').mockImplementation(() => {});
+    (repo as any).tableMetadata = {
+      columns: [
+        { name: '_id', isPrimary: true },
+        { name: 'name', isPublished: true },
+        { name: 'active', type: 'boolean', isPublished: false },
+        { name: 'score', type: 'int', isPublished: false },
+      ],
+    };
+
+    await repo.update({
+      id: 'row-1',
+      data: {
+        name: 'updated name',
+        active: false,
+        score: 0,
+      },
+    });
+
+    expect(queryBuilderService.update).toHaveBeenCalledWith(
+      'enfyra_route',
+      'row-1',
+      expect.objectContaining({
+        name: 'updated name',
+        active: false,
+        score: 0,
+      }),
+    );
+  });
+
   it('keeps Mongo string/ObjectId-like publicMethods when they are available', () => {
     const repo = makeRepo();
     const getId = '507f1f77bcf86cd799439011';


### PR DESCRIPTION
Strip empty unpublished fields from dynamic update payloads

- Fixed: `DynamicRepository.update()` now removes `isPublished=false` columns from the patch body when the submitted value is `null`/empty string for string-like types, so the eApp form cannot wipe hidden field values.
- Preserves `false` and `0` for boolean/numeric columns.
- Bump version to `2.2.15-patch-2`.