### PR TITLE
Release v2.2.16-patch-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.2.16",
+  "version": "2.2.16-patch-1",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "license": "Elastic-2.0",

--- a/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
+++ b/src/engines/cache/services/runtime-namespace-lifecycle.service.ts
@@ -159,7 +159,6 @@ export class RuntimeNamespaceLifecycleService {
 
   private renewableNamespacePatterns(namespace: string): string[] {
     return [
-      `${namespace}:runtime_lifecycle:*`,
       `${namespace}:runtime_cache:*`,
       `${namespace}:runtime-monitor:*`,
       `${namespace}:cluster-telemetry:*`,

--- a/src/engines/knex/knex.service.ts
+++ b/src/engines/knex/knex.service.ts
@@ -531,6 +531,13 @@ export class KnexService implements LifecycleAware {
     return this.getKnexForWrite() as Knex;
   }
 
+  getUnscopedWriteKnex(): Knex {
+    if (!this.knexInstance) {
+      throw new Error('Knex instance not initialized. Call init first.');
+    }
+    return this.replicationManager?.getMasterKnex() || this.knexInstance;
+  }
+
   private async runWithRuntimeWriteLease<T>(
     callback: () => Promise<T>,
     context: string,

--- a/src/engines/knex/services/schema-migration-lock.service.ts
+++ b/src/engines/knex/services/schema-migration-lock.service.ts
@@ -33,14 +33,14 @@ export class SchemaMigrationLockService {
     if (!handle) {
       return;
     }
-    const knex = this.knexService.getKnex();
+    const knex = this.getLockKnex();
 
     await this.clearLockRow(knex, handle.token);
   }
 
   async isStillHeld(handle: SchemaMigrationLockHandle): Promise<boolean> {
     if (!handle) return false;
-    const knex = this.knexService.getKnex();
+    const knex = this.getLockKnex();
     await this.ensureLockTable();
     const query = knex(this.tableName).where({
       id: 1,
@@ -117,7 +117,7 @@ export class SchemaMigrationLockService {
     if (!handle) {
       return false;
     }
-    const knex = this.knexService.getKnex();
+    const knex = this.getLockKnex();
     const dbType = this.queryBuilderService.getDatabaseType() || 'mysql';
 
     try {
@@ -143,7 +143,7 @@ export class SchemaMigrationLockService {
     context: string,
     token: string,
   ): Promise<SchemaMigrationLockHandle> {
-    const knex = this.knexService.getKnex();
+    const knex = this.getLockKnex();
     await this.ensureLockTable();
 
     const handle = await knex.transaction(async (trx) => {
@@ -228,7 +228,7 @@ export class SchemaMigrationLockService {
       return;
     }
 
-    const baseKnex = this.knexService.getKnex();
+    const baseKnex = this.getLockKnex();
     const exists = await baseKnex.schema.hasTable(this.tableName);
     if (!exists) {
       await baseKnex.schema.createTable(this.tableName, (table) => {
@@ -357,6 +357,10 @@ export class SchemaMigrationLockService {
         await knex(this.tableName).where({ id: 1 }).update(updatePayload);
       }
     }
+  }
+
+  private getLockKnex(): Knex {
+    return this.knexService.getUnscopedWriteKnex();
   }
 
   private async buildLockedError(knex: KnexLike): Promise<DatabaseException> {

--- a/src/modules/table-management/services/runtime-metadata-schema-router.service.ts
+++ b/src/modules/table-management/services/runtime-metadata-schema-router.service.ts
@@ -67,11 +67,7 @@ export class RuntimeMetadataSchemaRouterService {
       confirmHash !== requiredConfirmHash
     ) {
       return {
-        preview: {
-          _preview: true,
-          requiredConfirmHash,
-          schemaMutationContract: contract,
-        },
+        preview: this.buildPreview(contract, requiredConfirmHash),
         ownerTableId,
       };
     }
@@ -167,11 +163,7 @@ export class RuntimeMetadataSchemaRouterService {
       confirmHash !== requiredConfirmHash
     ) {
       return {
-        preview: {
-          _preview: true,
-          requiredConfirmHash,
-          schemaMutationContract: contract,
-        },
+        preview: this.buildPreview(contract, requiredConfirmHash),
         ownerTableId,
         recordId: input.recordId,
       };
@@ -236,11 +228,7 @@ export class RuntimeMetadataSchemaRouterService {
     const confirmHash = this.extractConfirmHash(input.context);
     if (confirmHash !== requiredConfirmHash) {
       return {
-        preview: {
-          _preview: true,
-          requiredConfirmHash,
-          schemaMutationContract: contract,
-        },
+        preview: this.buildPreview(contract, requiredConfirmHash),
         ownerTableId,
         recordId: input.recordId,
       };
@@ -295,11 +283,7 @@ export class RuntimeMetadataSchemaRouterService {
       confirmHash !== requiredConfirmHash
     ) {
       return {
-        preview: {
-          _preview: true,
-          requiredConfirmHash,
-          schemaMutationContract: contract,
-        },
+        preview: this.buildPreview(contract, requiredConfirmHash),
       };
     }
     const execResult = await this.deps.runtimeSchemaExecutorService.execute({
@@ -371,11 +355,7 @@ export class RuntimeMetadataSchemaRouterService {
       confirmHash !== requiredConfirmHash
     ) {
       return {
-        preview: {
-          _preview: true,
-          requiredConfirmHash,
-          schemaMutationContract: contract,
-        },
+        preview: this.buildPreview(contract, requiredConfirmHash),
       };
     }
     const execResult = await this.deps.runtimeSchemaExecutorService.execute({
@@ -437,11 +417,7 @@ export class RuntimeMetadataSchemaRouterService {
     const confirmHash = this.extractConfirmHash(input.context);
     if (confirmHash !== requiredConfirmHash) {
       return {
-        preview: {
-          _preview: true,
-          requiredConfirmHash,
-          schemaMutationContract: contract,
-        },
+        preview: this.buildPreview(contract, requiredConfirmHash),
       };
     }
     const execResult = await this.deps.runtimeSchemaExecutorService.execute({
@@ -743,11 +719,42 @@ export class RuntimeMetadataSchemaRouterService {
   }
 
   private extractConfirmHash(context: any): string | undefined {
-    return (
+    const value =
       context?.$query?.schemaConfirmHash ??
+      context?.$query?.schema_confirm_hash ??
       context?.$query?.confirmHash ??
-      undefined
-    );
+      context?.$query?.confirm_hash;
+    return typeof value === 'string' ? value.trim().toLowerCase() : undefined;
+  }
+
+  private buildPreview(contract: any, requiredConfirmHash: string): Record<string, any> {
+    const diff = contract.context?.diff ?? {};
+    return {
+      _preview: true,
+      tableName: diff.tableName,
+      operation: diff.operation,
+      schemaChanged: diff.schemaChanged,
+      policyMetadataChanged: diff.policyMetadataChanged,
+      isDestructive: diff.isDestructive,
+      removedColumns: diff.removedColumns ?? [],
+      addedColumns: diff.addedColumns ?? [],
+      renamedColumns: diff.renamedColumns ?? [],
+      changedColumns: diff.changedColumns ?? [],
+      removedRelationsCount: Array.isArray(diff.removedRelations)
+        ? diff.removedRelations.length
+        : 0,
+      addedRelationsCount: Array.isArray(diff.addedRelations)
+        ? diff.addedRelations.length
+        : 0,
+      removedUniques: diff.removedUniques ?? [],
+      addedUniques: diff.addedUniques ?? [],
+      removedIndexes: diff.removedIndexes ?? [],
+      addedIndexes: diff.addedIndexes ?? [],
+      owningSideInverseCascadeWarnings:
+        diff.owningSideInverseCascadeWarnings ?? [],
+      requiredConfirmHash,
+      schemaMutationContract: contract,
+    };
   }
 
   private validateColumns(body: TCreateTableBody): void {

--- a/src/modules/table-management/services/runtime-schema-contract-compiler.service.ts
+++ b/src/modules/table-management/services/runtime-schema-contract-compiler.service.ts
@@ -59,16 +59,29 @@ export class RuntimeSchemaContractCompilerService {
       backend,
       mode: 'persisted',
     });
-    const sourcePolicyMetadata = normalizeRuntimePolicyMetadata(input.beforeMetadata);
-    const targetPolicyMetadata = normalizeRuntimePolicyMetadata(targetInput);
+    const sourcePolicyMetadata = normalizeRuntimePolicyMetadata(
+      input.beforeMetadata,
+      { includeEmptySubjects: false },
+    );
+    const targetPolicyMetadata = normalizeRuntimePolicyMetadata(targetInput, {
+      includeEmptySubjects: false,
+    });
     const sourcePolicyMetadataRevision = sourcePolicyMetadata
       ? hashCanonical(sourcePolicyMetadata)
       : null;
     const targetPolicyMetadataRevision = targetPolicyMetadata
       ? hashCanonical(targetPolicyMetadata)
       : null;
-    const policyMetadataChanged =
-      sourcePolicyMetadataRevision !== targetPolicyMetadataRevision;
+    const sourcePolicyMetadataForDiff = normalizeRuntimePolicyMetadata(
+      input.beforeMetadata,
+      { includeEmptySubjects: false },
+    );
+    const targetPolicyMetadataForDiff = normalizeRuntimePolicyMetadata(
+      targetInput,
+      { includeEmptySubjects: false },
+    );
+    const policyMetadataChanged = hashCanonical(sourcePolicyMetadataForDiff)
+      !== hashCanonical(targetPolicyMetadataForDiff);
     const warnings = await this.collectCascadeWarnings(
       input.beforeMetadata,
       before?.contract.relations ?? [],

--- a/src/modules/table-management/utils/runtime-schema-normalization.util.ts
+++ b/src/modules/table-management/utils/runtime-schema-normalization.util.ts
@@ -26,8 +26,12 @@ export interface NormalizedRuntimeTableSchema {
   keyedColumns: readonly KeyedRuntimeSchemaColumn[];
 }
 
-export function normalizeRuntimePolicyMetadata(metadata: unknown): unknown | null {
+export function normalizeRuntimePolicyMetadata(
+  metadata: unknown,
+  options: { includeEmptySubjects?: boolean } = {},
+): unknown | null {
   if (!metadata || typeof metadata !== 'object') return null;
+  const includeEmptySubjects = options.includeEmptySubjects === true;
   const value = metadata as Record<string, any>;
   const normalizeEntries = (entries: unknown, kind: 'permission' | 'rule') => {
     if (!Array.isArray(entries)) return [];
@@ -63,18 +67,20 @@ export function normalizeRuntimePolicyMetadata(metadata: unknown): unknown | nul
   };
   const normalizeSubjects = (items: unknown, identity: 'column' | 'relation') =>
     (Array.isArray(items) ? items : [])
+      .filter((item: any) => item && typeof item === 'object')
+      .map((item: any) => {
+        const fieldPermissions = normalizeEntries(item?.fieldPermissions, 'permission');
+        const rules = normalizeEntries(item?.rules, 'rule');
+        return normalizeJsonValue({
+          key: stringValue(item?.name ?? item?.propertyName ?? item?.id ?? item?._id),
+          fieldPermissions,
+          rules,
+          identity,
+        });
+      })
       .filter(
         (item: any) =>
-          Object.prototype.hasOwnProperty.call(item ?? {}, 'fieldPermissions') ||
-          Object.prototype.hasOwnProperty.call(item ?? {}, 'rules'),
-      )
-      .map((item: any) =>
-        normalizeJsonValue({
-          key: stringValue(item?.name ?? item?.propertyName ?? item?.id ?? item?._id),
-          fieldPermissions: normalizeEntries(item?.fieldPermissions, 'permission'),
-          rules: normalizeEntries(item?.rules, 'rule'),
-          identity,
-        }),
+          includeEmptySubjects || item.fieldPermissions.length > 0 || item.rules.length > 0,
       )
       .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
   return {

--- a/test/cache/runtime-namespace-lifecycle.service.spec.ts
+++ b/test/cache/runtime-namespace-lifecycle.service.spec.ts
@@ -173,6 +173,22 @@ describe('RuntimeNamespaceLifecycleService', () => {
     );
   });
 
+  it('does not extend a lease from a previous process', async () => {
+    const redis = new FakeRedis();
+    redis.values.set('app-a:runtime_lifecycle:lease:previous-instance', 'old');
+    redis.expiries.set('app-a:runtime_lifecycle:lease:previous-instance', 100);
+
+    const service = createService(redis);
+    await service.renewCurrentNamespaceKeys();
+
+    expect(redis.expiries.get('app-a:runtime_lifecycle:lease:inst-a')).toBe(
+      1000,
+    );
+    expect(
+      redis.expiries.get('app-a:runtime_lifecycle:lease:previous-instance'),
+    ).toBe(100);
+  });
+
   it('renews one system queue namespace on demand', async () => {
     const redis = new FakeRedis();
     redis.values.set('app-a:sys_flow-execution:wait', 'queue');

--- a/test/domain/runtime-metadata-schema-router.spec.ts
+++ b/test/domain/runtime-metadata-schema-router.spec.ts
@@ -66,8 +66,22 @@ function createHarness(input?: {
     contractHash: 'test-hash',
     context: {
       diff: {
+        tableName: 'post',
+        operation: 'update',
         schemaChanged: true,
+        policyMetadataChanged: false,
         isDestructive: input?.preview === true,
+        removedColumns: [],
+        addedColumns: [],
+        renamedColumns: [],
+        changedColumns: [],
+        removedRelations: [],
+        addedRelations: [],
+        removedUniques: [],
+        addedUniques: [],
+        removedIndexes: [],
+        addedIndexes: [],
+        owningSideInverseCascadeWarnings: [],
       },
     },
   };
@@ -104,6 +118,7 @@ function createHarness(input?: {
     runtimeSchemaContractCompilerService,
     runtimeSchemaExecutorService,
     ownerTable,
+    contract,
   };
 }
 
@@ -268,6 +283,36 @@ describe('RuntimeMetadataSchemaRouterService', () => {
     expect(result.preview!._preview).toBe(true);
     expect(result.preview!.requiredConfirmHash).toBe('confirm-me');
     expect(harness.runtimeSchemaExecutorService.execute).not.toHaveBeenCalled();
+  });
+
+  it('accepts the snake_case confirmation query used by the app', async () => {
+    const harness = createHarness();
+
+    const result = await harness.service.updateTable({
+      tableId: 10,
+      body: { description: 'Updated description' },
+      context: { $query: { schema_confirm_hash: 'confirm-me' } } as any,
+    });
+
+    expect(result.preview).toBeUndefined();
+    expect(harness.runtimeSchemaExecutorService.execute).toHaveBeenCalledOnce();
+  });
+
+  it('exposes flattened diff details in a schema preview', async () => {
+    const harness = createHarness();
+    harness.contract.context.diff.changedColumns = ['title'];
+
+    const result = await harness.service.updateTable({
+      tableId: 10,
+      body: { description: 'Updated description' },
+    });
+
+    expect(result.preview).toEqual(expect.objectContaining({
+      _preview: true,
+      changedColumns: ['title'],
+      addedRelationsCount: 0,
+      removedRelationsCount: 0,
+    }));
   });
 
   it('routes relation deletion through a complete replacement aggregate', async () => {

--- a/test/domain/runtime-schema-contract-compiler.spec.ts
+++ b/test/domain/runtime-schema-contract-compiler.spec.ts
@@ -191,6 +191,27 @@ describe('RuntimeSchemaContractCompilerService', () => {
     expect(result.contract.phases).toEqual([]);
   });
 
+  it('treats publication visibility changes as altered columns', async () => {
+    const result = await createCompiler().compile({
+      operation: 'update',
+      tableName: 'post',
+      tableId: 7,
+      beforeMetadata: baseTable,
+      afterMetadata: {
+        ...baseTable,
+        columns: [
+          baseTable.columns[0],
+          { ...baseTable.columns[1], isPublished: false },
+        ],
+      },
+    });
+
+    expect(result.contract.context.diff.changedColumns).toEqual(['title']);
+    expect(result.contract.changes).toEqual([
+      expect.objectContaining({ kind: 'alter-column', label: 'alter column title' }),
+    ]);
+  });
+
   it('compiles table metadata-only changes into executable phases', async () => {
     const compiler = createCompiler();
     const result = await compiler.compile({
@@ -264,5 +285,113 @@ describe('RuntimeSchemaContractCompilerService', () => {
       ]),
     );
     expect(result.contract.phases).not.toEqual([]);
+  });
+
+  it('treats omitted policy collections on a new column as empty', async () => {
+    const compiler = createCompiler();
+    const before = {
+      ...baseTable,
+      columns: baseTable.columns.map((column) => ({
+        ...column,
+        fieldPermissions: [],
+        rules: [],
+      })),
+    };
+    const addedColumn = {
+      id: 3,
+      name: 'transport',
+      type: 'enum',
+      isNullable: false,
+      isPrimary: false,
+      isGenerated: false,
+      defaultValue: 'unified',
+      options: ['unified', 'codex'],
+    };
+    const omittedPolicy = await compiler.compile({
+      operation: 'update',
+      tableName: 'post',
+      tableId: 7,
+      beforeMetadata: before,
+      afterMetadata: {
+        ...before,
+        columns: [...before.columns, addedColumn],
+      },
+    });
+    const materializedPolicy = await compiler.compile({
+      operation: 'update',
+      tableName: 'post',
+      tableId: 7,
+      beforeMetadata: before,
+      afterMetadata: {
+        ...before,
+        columns: [
+          ...before.columns,
+          { ...addedColumn, fieldPermissions: [], rules: [] },
+        ],
+      },
+    });
+
+    expect(
+      omittedPolicy.contract.context.targetPolicyMetadataRevision,
+    ).toBe(materializedPolicy.contract.context.targetPolicyMetadataRevision);
+    expect(omittedPolicy.contract.context.diff.policyMetadataChanged).toBe(false);
+  });
+
+  it('does not include policy-empty generated timestamp columns in policy revision', async () => {
+    const compiler = createCompiler();
+    const policyColumn = {
+      id: 3,
+      name: 'secret',
+      type: 'varchar',
+      isNullable: true,
+      isPrimary: false,
+      isGenerated: false,
+      defaultValue: null,
+      fieldPermissions: [
+        { id: 9, action: 'read', effect: 'deny', role: { id: 2 } },
+      ],
+      rules: [],
+    };
+    const logicalTarget = {
+      ...baseTable,
+      columns: [...baseTable.columns, policyColumn],
+    };
+    const persistedTarget = {
+      ...logicalTarget,
+      columns: [
+        ...logicalTarget.columns,
+        {
+          name: 'createdAt',
+          type: 'datetime',
+          fieldPermissions: [],
+          rules: [],
+        },
+        {
+          name: 'updatedAt',
+          type: 'datetime',
+          fieldPermissions: [],
+          rules: [],
+        },
+      ],
+    };
+
+    const logical = await compiler.compile({
+      operation: 'update',
+      tableName: 'post',
+      tableId: 7,
+      beforeMetadata: logicalTarget,
+      afterMetadata: logicalTarget,
+    });
+    const persisted = await compiler.compile({
+      operation: 'update',
+      tableName: 'post',
+      tableId: 7,
+      beforeMetadata: logicalTarget,
+      afterMetadata: persistedTarget,
+    });
+
+    expect(logical.contract.context.targetPolicyMetadataRevision).toBe(
+      persisted.contract.context.targetPolicyMetadataRevision,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Canonicalized runtime schema policy revisions across eApp and ESV.
- Hardened schema migration lock operations against aborted ambient transactions.
- Fixed runtime lifecycle lease renewal to avoid retaining prior process leases.
- Bumped ESV version to 2.2.16-patch-1.

## Verification
- Focused schema, metadata router, migration lock, and lifecycle tests: 39 passed.
- yarn tsc --noEmit --pretty false