### PR TITLE
Release v2.2.16-patch-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.2.16-patch-1",
+  "version": "2.2.16-patch-2",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "license": "Elastic-2.0",

--- a/src/modules/table-management/services/runtime-metadata-schema-router.service.ts
+++ b/src/modules/table-management/services/runtime-metadata-schema-router.service.ts
@@ -48,7 +48,7 @@ export class RuntimeMetadataSchemaRouterService {
     const child = this.normalizeChild(input.tableName, input.data ?? {});
     list.push(child);
     body = this.normalizeCompleteTableConstraints(body);
-    this.validateColumns(body);
+    this.validateSchemaBody(body);
     body = await this.resolveRelationTargetNames(body);
     const { contract, requiredConfirmHash } =
       await this.deps.runtimeSchemaContractCompilerService.compile({
@@ -129,11 +129,13 @@ export class RuntimeMetadataSchemaRouterService {
       );
     }
     const previousChild = list[index];
-    list[index] = this.normalizeChild(input.tableName, {
-      ...list[index],
-      ...input.data,
-      [this.getPkField()]: input.recordId,
-    });
+    list[index] = this.normalizeChild(
+      input.tableName,
+      this.mergeNestedSchemaSubject(list[index], {
+        ...input.data,
+        [this.getPkField()]: input.recordId,
+      }),
+    );
     const fieldRenames = new Map<string, string>();
     if (
       input.tableName === 'enfyra_column' &&
@@ -144,7 +146,7 @@ export class RuntimeMetadataSchemaRouterService {
       fieldRenames.set(previousChild.name, list[index].name);
     }
     body = this.normalizeCompleteTableConstraints(body, fieldRenames);
-    this.validateColumns(body);
+    this.validateSchemaBody(body);
     body = await this.resolveRelationTargetNames(body);
     const { contract, requiredConfirmHash } =
       await this.deps.runtimeSchemaContractCompilerService.compile({
@@ -263,7 +265,7 @@ export class RuntimeMetadataSchemaRouterService {
     input: RuntimeTableMutationInput,
   ): Promise<RuntimeMetadataSchemaMutationResult> {
     const body = this.normalizeCompleteTableConstraints(input.body!);
-    this.validateColumns(body);
+    this.validateSchemaBody(body);
     const resolvedBody = await this.resolveRelationTargetNames(body);
     this.assertNotReservedTableName(String(resolvedBody.name));
     const { contract, requiredConfirmHash } =
@@ -334,7 +336,7 @@ export class RuntimeMetadataSchemaRouterService {
     const target = await this.resolveRelationTargetNames(
       this.buildCompleteTarget(existing, body),
     );
-    this.validateColumns(target);
+    this.validateSchemaBody(target);
     if (target.name !== existing.name) {
       this.assertNotReservedTableName(String(target.name));
     }
@@ -484,7 +486,7 @@ export class RuntimeMetadataSchemaRouterService {
           if (match.name && col.name && match.name !== col.name) {
             fieldRenames.set(match.name, col.name);
           }
-          return { ...match, ...col };
+          return this.mergeNestedSchemaSubject(match, col);
         }
         return col;
       });
@@ -513,12 +515,47 @@ export class RuntimeMetadataSchemaRouterService {
           ) {
             fieldRenames.set(match.propertyName, rel.propertyName);
           }
-          return { ...match, ...rel };
+          return this.mergeNestedSchemaSubject(match, rel);
         }
         return rel;
       });
     }
     return this.normalizeCompleteTableConstraints(target, fieldRenames);
+  }
+
+  private mergeNestedSchemaSubject(existing: any, incoming: any): any {
+    return {
+      ...existing,
+      ...incoming,
+      ...(Array.isArray(incoming.fieldPermissions) && {
+        fieldPermissions: this.mergeNestedSchemaMetadata(
+          existing.fieldPermissions,
+          incoming.fieldPermissions,
+        ),
+      }),
+      ...(Array.isArray(incoming.rules) && {
+        rules: this.mergeNestedSchemaMetadata(existing.rules, incoming.rules),
+      }),
+    };
+  }
+
+  private mergeNestedSchemaMetadata(
+    existingEntries: unknown,
+    incomingEntries: unknown[],
+  ): unknown[] {
+    if (!Array.isArray(existingEntries)) return incomingEntries;
+    const existingById = new Map(
+      existingEntries
+        .filter((entry: any) => entry && typeof entry === 'object')
+        .map((entry: any) => [String(this.getRecordId(entry)), entry]),
+    );
+    return incomingEntries.map((entry: any) => {
+      if (!entry || typeof entry !== 'object') return entry;
+      const entryId = this.getRecordId(entry);
+      if (entryId == null) return entry;
+      const existing = existingById.get(String(entryId));
+      return existing ? { ...existing, ...entry } : entry;
+    });
   }
 
   private normalizeCompleteTableConstraints(
@@ -761,6 +798,13 @@ export class RuntimeMetadataSchemaRouterService {
     this.deps.tableManagementValidationService.validateColumns(
       body.columns,
       this.deps.databaseConfigService.getDbType(),
+    );
+  }
+
+  private validateSchemaBody(body: TCreateTableBody): void {
+    this.validateColumns(body);
+    this.deps.tableManagementValidationService.validateRelations(
+      body.relations ?? [],
     );
   }
 

--- a/src/modules/table-management/services/sql-table-metadata-writer.service.ts
+++ b/src/modules/table-management/services/sql-table-metadata-writer.service.ts
@@ -486,16 +486,18 @@ export class SqlTableMetadataWriterService {
       .where({ [opts.subjectFk]: opts.subjectFkValue })
       .select('id');
     const deletedIds = getDeletedIds(existing, opts.permissions);
-    if (deletedIds.length > 0 && allowedUsersJunction) {
-      const junctionRows = await queryRunner(
-        allowedUsersJunction.junctionTableName,
-      )
-        .whereIn(allowedUsersJunction.junctionSourceColumn, deletedIds)
-        .select('*');
-      if (Array.isArray(junctionRows) && junctionRows.length > 0) {
-        await queryRunner(allowedUsersJunction.junctionTableName)
+    if (deletedIds.length > 0) {
+      if (allowedUsersJunction) {
+        const junctionRows = await queryRunner(
+          allowedUsersJunction.junctionTableName,
+        )
           .whereIn(allowedUsersJunction.junctionSourceColumn, deletedIds)
-          .delete();
+          .select('*');
+        if (Array.isArray(junctionRows) && junctionRows.length > 0) {
+          await queryRunner(allowedUsersJunction.junctionTableName)
+            .whereIn(allowedUsersJunction.junctionSourceColumn, deletedIds)
+            .delete();
+        }
       }
       await queryRunner('enfyra_field_permission')
         .whereIn('id', deletedIds)

--- a/src/modules/table-management/services/table-validation.service.ts
+++ b/src/modules/table-management/services/table-validation.service.ts
@@ -33,6 +33,15 @@ export class TableManagementValidationService {
 
   validateRelations(relations: any[]) {
     for (const relation of relations || []) {
+      if (Array.isArray(relation.rules) && relation.rules.length > 0) {
+        throw new ValidationException(
+          `Relation '${relation.propertyName}' does not support validation rules`,
+          {
+            code: 'SCHEMA_RELATION_RULES_UNSUPPORTED',
+            relationName: relation.propertyName,
+          },
+        );
+      }
       if (relation.type === 'one-to-many' && !relation.mappedBy) {
         throw new ValidationException(
           `One-to-many relation '${relation.propertyName}' must have mappedBy`,

--- a/test/table-management/field-permission-junction-writer.spec.ts
+++ b/test/table-management/field-permission-junction-writer.spec.ts
@@ -32,7 +32,7 @@ describe('SqlTableMetadataWriterService field-permission junctions', () => {
     );
   });
 
-  it('skips optional junction cleanup when no physical table exists', async () => {
+  it('deletes permissions even when no allowed-users junction table exists', async () => {
     const calls: string[] = [];
     const runner: any = (table: string) => {
       calls.push(table);
@@ -55,6 +55,9 @@ describe('SqlTableMetadataWriterService field-permission junctions', () => {
       subjectFkValue: 10,
     });
 
-    expect(calls).toEqual(['enfyra_field_permission']);
+    expect(calls).toEqual([
+      'enfyra_field_permission',
+      'enfyra_field_permission',
+    ]);
   });
 });

--- a/test/table-management/runtime-metadata-schema-router.spec.ts
+++ b/test/table-management/runtime-metadata-schema-router.spec.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RuntimeMetadataSchemaRouterService } from '../../src/modules/table-management/services/runtime-metadata-schema-router.service';
+import { TableManagementValidationService } from '../../src/modules/table-management/services/table-validation.service';
+
+function createRouter() {
+  return new RuntimeMetadataSchemaRouterService({
+    databaseConfigService: {
+      isMongoDb: () => false,
+      getDbType: () => 'postgres',
+    },
+  } as any);
+}
+
+describe('RuntimeMetadataSchemaRouterService', () => {
+  it('preserves complete nested policy metadata when the request carries only child ids', () => {
+    const existingPermission = {
+      id: 41,
+      action: 'read',
+      effect: 'allow',
+      condition: null,
+      description: 'Local regression fixture',
+      isEnabled: true,
+      role: { id: 1 },
+      allowedUsers: [],
+    };
+    const existingRule = {
+      id: 8,
+      ruleType: 'required',
+      value: true,
+      message: 'Required',
+      description: null,
+      isEnabled: true,
+    };
+    const router = createRouter();
+
+    const target = (router as any).buildCompleteTarget(
+      {
+        name: 'example',
+        indexes: [],
+        uniques: [],
+        columns: [
+          {
+            id: 7,
+            name: 'secret',
+            type: 'varchar',
+            fieldPermissions: [existingPermission],
+            rules: [existingRule],
+          },
+        ],
+        relations: [],
+      },
+      {
+        columns: [
+          {
+            id: 7,
+            name: 'secret',
+            type: 'varchar',
+            isPublished: true,
+            fieldPermissions: [{ id: 41 }],
+            rules: [{ id: 8 }],
+          },
+        ],
+      },
+    );
+
+    expect(target.columns[0].fieldPermissions).toEqual([existingPermission]);
+    expect(target.columns[0].rules).toEqual([existingRule]);
+  });
+
+  it('preserves complete nested policy metadata for direct child updates with id-only entries', async () => {
+    const existingPermission = {
+      id: 41,
+      action: 'read',
+      effect: 'allow',
+      condition: null,
+      description: 'Local regression fixture',
+      isEnabled: true,
+      role: { id: 1 },
+      allowedUsers: [],
+    };
+    const existingRule = {
+      id: 8,
+      ruleType: 'required',
+      value: true,
+      message: 'Required',
+      description: null,
+      isEnabled: true,
+    };
+    const compile = vi.fn().mockResolvedValue({
+      contract: { context: { diff: { isDestructive: false } } },
+      requiredConfirmHash: 'confirm',
+    });
+    const router = new RuntimeMetadataSchemaRouterService({
+      databaseConfigService: {
+        isMongoDb: () => false,
+        getDbType: () => 'postgres',
+      },
+      queryBuilderService: {
+        findOne: vi.fn().mockResolvedValue({
+          id: 99,
+          name: 'example',
+          indexes: [],
+          uniques: [],
+          columns: [
+            {
+              id: 7,
+              name: 'secret',
+              type: 'varchar',
+              fieldPermissions: [existingPermission],
+              rules: [existingRule],
+            },
+          ],
+          relations: [],
+        }),
+      },
+      tableManagementValidationService: {
+        validateColumns: vi.fn(),
+        validateRelations: vi.fn(),
+      },
+      runtimeSchemaContractCompilerService: { compile },
+      runtimeSchemaExecutorService: {
+        execute: vi.fn().mockResolvedValue({ affectedTables: [] }),
+      },
+    } as any);
+
+    await router.update({
+      tableName: 'enfyra_column',
+      recordId: 7,
+      existing: { id: 7, table: { id: 99 } },
+      data: {
+        isPublished: true,
+        fieldPermissions: [{ id: 41 }],
+        rules: [{ id: 8 }],
+      },
+      context: { $query: {} },
+    });
+
+    const input = compile.mock.calls[0][0];
+    expect(input.afterMetadata.columns[0].fieldPermissions).toEqual([
+      existingPermission,
+    ]);
+    expect(input.afterMetadata.columns[0].rules).toEqual([existingRule]);
+  });
+
+  it('rejects unsupported validation rules on relations before compiling the schema contract', async () => {
+    const compile = vi.fn().mockResolvedValue({
+      contract: { context: { diff: { isDestructive: false } } },
+      requiredConfirmHash: 'confirm',
+    });
+    const router = new RuntimeMetadataSchemaRouterService({
+      databaseConfigService: {
+        isMongoDb: () => false,
+        getDbType: () => 'postgres',
+      },
+      tableManagementValidationService: new TableManagementValidationService(),
+      runtimeSchemaContractCompilerService: { compile },
+      runtimeSchemaExecutorService: {
+        execute: vi.fn().mockResolvedValue({ affectedTables: [] }),
+      },
+    } as any);
+
+    await expect(
+      router.createTable({
+        body: {
+          name: 'example',
+          columns: [],
+          relations: [
+            {
+              propertyName: 'owner',
+              type: 'many-to-one',
+              rules: [{ ruleType: 'required' }],
+            },
+          ],
+        } as any,
+        context: { $query: {} },
+      }),
+    ).rejects.toThrow('not support validation rules');
+
+    expect(compile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Bug fixes

- Preserved hydrated nested policy/rule metadata when schema aggregate or child updates contain id-only entries.
- Removed residual SQL field permissions when optional allowed-users junction storage is absent.
- Rejected unsupported relation validation rules before schema contract compilation.

## Verification

- `yarn build`
- Focused schema regression suite (23 tests)