### PR TITLE
Release v2.2.16-patch-3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.2.16-patch-2",
+  "version": "2.2.16-patch-3",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "license": "Elastic-2.0",

--- a/src/engines/knex/utils/provision/schema-comparison.ts
+++ b/src/engines/knex/utils/provision/schema-comparison.ts
@@ -501,6 +501,11 @@ export function isTypeCompatible(type1: string, type2: string): boolean {
       'datetime',
       'timestamp without time zone',
       'timestamp with time zone',
+      // Enfyra `date` columns are created as physical DATE by the runtime
+      // DDL path (column-operations/sql-generator) while getKnexColumnType
+      // normalizes date/datetime/timestamp to 'timestamp'. Accept physical
+      // DATE so runtime-added date columns pass target attestation.
+      'date',
     ],
     boolean: ['tinyint', 'boolean', 'bool'],
     real: ['real', 'float', 'double precision'],

--- a/src/modules/table-management/services/runtime-metadata-schema-router.service.ts
+++ b/src/modules/table-management/services/runtime-metadata-schema-router.service.ts
@@ -17,6 +17,7 @@ import type { RuntimeSchemaContractCompilerService } from './runtime-schema-cont
 import type { RuntimeSchemaExecutorService } from './runtime-schema-executor.service';
 import { getSqlJunctionPhysicalNames } from '../utils/sql-junction-naming.util';
 import { normalizeTableConstraints } from '../utils/table-constraints.util';
+import { RUNTIME_SCHEMA_METADATA_READ_DEEP } from '../utils/runtime-schema-metadata-read.util';
 import type { TableManagementValidationService } from './table-validation.service';
 
 export class RuntimeMetadataSchemaRouterService {
@@ -312,6 +313,7 @@ export class RuntimeMetadataSchemaRouterService {
     const existing = await this.deps.queryBuilderService.findOne({
       table: 'enfyra_table',
       where: { [this.getPkField()]: tableId },
+      deep: RUNTIME_SCHEMA_METADATA_READ_DEEP,
       fields: [
         '*',
         'columns.*',
@@ -385,6 +387,7 @@ export class RuntimeMetadataSchemaRouterService {
     const existing = await this.deps.queryBuilderService.findOne({
       table: 'enfyra_table',
       where: { [this.getPkField()]: tableId },
+      deep: RUNTIME_SCHEMA_METADATA_READ_DEEP,
       fields: [
         '*',
         'columns.*',
@@ -607,6 +610,7 @@ export class RuntimeMetadataSchemaRouterService {
     const table = await this.deps.queryBuilderService.findOne({
       table: 'enfyra_table',
       where: { [this.getPkField()]: ownerTableId },
+      deep: RUNTIME_SCHEMA_METADATA_READ_DEEP,
       fields: [
         '*',
         'columns.*',

--- a/src/modules/table-management/services/runtime-schema-executor.service.ts
+++ b/src/modules/table-management/services/runtime-schema-executor.service.ts
@@ -20,6 +20,7 @@ import {
   normalizeRuntimeTableSchema,
 } from '../utils/runtime-schema-normalization.util';
 import { formatRuntimeSchemaContractDiff } from '../utils/runtime-schema-contract-diff.util';
+import { RUNTIME_SCHEMA_METADATA_READ_DEEP } from '../utils/runtime-schema-metadata-read.util';
 import { hashCanonical } from '../../../shared/utils/schema-mutation-contract.util';
 import type { QueryBuilderService } from '@enfyra/kernel';
 import type { RuntimeSchemaTargetAttestorService } from './runtime-schema-target-attestor.service';
@@ -216,6 +217,7 @@ export class RuntimeSchemaExecutorService {
       where: expectedRevision && tableId != null
         ? { [pkField]: tableId }
         : { name: tableName },
+      deep: RUNTIME_SCHEMA_METADATA_READ_DEEP,
       fields: [
         '*',
         'columns.*',
@@ -301,6 +303,7 @@ export class RuntimeSchemaExecutorService {
       where: tableId != null
         ? { [pkField]: tableId }
         : { name: tableName },
+      deep: RUNTIME_SCHEMA_METADATA_READ_DEEP,
       fields: [
         '*',
         'columns.*',

--- a/src/modules/table-management/utils/runtime-schema-metadata-read.util.ts
+++ b/src/modules/table-management/utils/runtime-schema-metadata-read.util.ts
@@ -1,0 +1,32 @@
+// Deep-fetch options used when reading `enfyra_table` metadata for runtime
+// schema mutation. The generic query builder caps one-to-many / many-to-many
+// deep fetches at DEEP_TO_MANY_DEFAULT_LIMIT (10) unless an explicit limit is
+// provided, which silently truncates tables with more than 10 columns and
+// breaks revision hashing / target attestation. Passing `limit: 0` disables
+// the cap (the SQL adapter only applies a LIMIT clause when limit > 0), so
+// the full persisted schema is read.
+export const RUNTIME_SCHEMA_METADATA_READ_DEEP: Record<string, any> = {
+  columns: {
+    limit: 0,
+    deep: {
+      rules: { limit: 0 },
+      fieldPermissions: {
+        limit: 0,
+        deep: {
+          allowedUsers: { limit: 0 },
+        },
+      },
+    },
+  },
+  relations: {
+    limit: 0,
+    deep: {
+      fieldPermissions: {
+        limit: 0,
+        deep: {
+          allowedUsers: { limit: 0 },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Patch release v2.2.16-patch-3.

### Changes
- fix: full runtime schema metadata deep read and date type attestation
  - Read `enfyra_table` metadata with `limit: 0` deep fetches so tables with more than 10 columns/relations are not silently truncated (broke revision hashing / target attestation)
  - Accept physical `DATE` as compatible with date columns in type attestation
- Version bumped to `2.2.16-patch-3`