### PR TITLE
Release v2.2.16-patch-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.2.16-patch-3",
+  "version": "2.2.16-patch-4",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "license": "Elastic-2.0",

--- a/src/shared/utils/load-user-with-role.util.ts
+++ b/src/shared/utils/load-user-with-role.util.ts
@@ -63,10 +63,20 @@ export async function loadUserWithRole(
 
   if (!user) return null;
 
-  const roleField = isMongoDB ? 'role' : 'roleId';
+  const relationRole = user.role;
+  const rawRoleId = isMongoDB
+    ? relationRole &&
+      typeof relationRole === 'object' &&
+      !(relationRole instanceof ObjectId)
+      ? relationRole._id ?? relationRole.id
+      : relationRole
+    : user.roleId ??
+      (relationRole && typeof relationRole === 'object'
+        ? relationRole.id ?? relationRole._id
+        : relationRole);
   const roleId = isMongoDB
-    ? toMongoObjectId(user[roleField])
-    : toSqlId(user[roleField]);
+    ? toMongoObjectId(rawRoleId)
+    : toSqlId(rawRoleId);
   if (roleId) {
     user.role = await queryBuilder.findOne({
       table: 'enfyra_role',

--- a/test/domain/load-user-with-role.util.spec.ts
+++ b/test/domain/load-user-with-role.util.spec.ts
@@ -111,6 +111,33 @@ describe('loadUserWithRole', () => {
     expect(result?.role).toEqual(role);
   });
 
+  it('hydrates the full SQL role from the wildcard relation stub', async () => {
+    DatabaseConfigService.overrideForTesting('postgres');
+    const user = {
+      id: '6dcaf98d-07a0-4d7e-88ad-87dd1e3b113d',
+      email: 'member@example.com',
+      role: { id: 2 },
+    };
+    const role = { id: 2, name: 'Member' };
+    const findOne = vi.fn(async ({ table }) => {
+      if (table === 'enfyra_user') return user;
+      if (table === 'enfyra_role') return role;
+      return null;
+    });
+    const queryBuilder = {
+      isMongoDb: () => false,
+      findOne,
+    } as any;
+
+    const result = await loadUserWithRole(queryBuilder, user.id);
+
+    expect(findOne).toHaveBeenNthCalledWith(2, {
+      table: 'enfyra_role',
+      where: { id: 2 },
+    });
+    expect(result?.role).toEqual(role);
+  });
+
   it('returns local cached users without querying the database', async () => {
     DatabaseConfigService.overrideForTesting('postgres');
     const cachedUser = { id: '1', email: 'cached@example.com' };


### PR DESCRIPTION
## Summary
- Fixed SQL role hydration when wildcard relation data returns a role object stub.
- Added regression coverage for PostgreSQL role lookup.
- Bumped server version to 2.2.16-patch-4.

## Verification
- NODE_OPTIONS='--no-node-snapshot' yarn vitest run test/domain/load-user-with-role.util.spec.ts
- yarn tsc --noEmit --pretty false
- yarn build