### PR TITLE
Release v2.2.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-server",
-  "version": "2.2.16-patch-4",
+  "version": "2.2.17",
   "description": "Dynamic backend platform that auto-generates REST and GraphQL APIs from database schemas",
   "author": "dothinh115 <dothinh115@gmail.com>",
   "license": "Elastic-2.0",

--- a/src/engines/knex/services/sql-schema-diff.service.ts
+++ b/src/engines/knex/services/sql-schema-diff.service.ts
@@ -260,10 +260,34 @@ export class SqlSchemaDiffService {
         diff.metadataUpdate.indexes = finalIndexes;
       }
     } else if (!this.arraysEqual(oldUniques, newUniques)) {
-      diff.constraints.uniques.update = buildSqlUniqueContracts(
+      const oldPhysicalUniques = buildSqlUniqueContracts(
+        oldMetadata.name,
+        oldMetadata,
+      ).map((unique) => unique.physicalColumns);
+      const newPhysicalUniques = buildSqlUniqueContracts(
         newMetadata.name,
         newMetadata,
       ).map((unique) => unique.physicalColumns);
+      const oldUniqueKeys = new Set(
+        oldPhysicalUniques.map((columns) => this.indexKey(columns)),
+      );
+      const newUniqueKeys = new Set(
+        newPhysicalUniques.map((columns) => this.indexKey(columns)),
+      );
+      const toDelete = oldPhysicalUniques.filter(
+        (columns) =>
+          columns.length > 0 && !newUniqueKeys.has(this.indexKey(columns)),
+      );
+      const toCreate = newPhysicalUniques.filter(
+        (columns) =>
+          columns.length > 0 && !oldUniqueKeys.has(this.indexKey(columns)),
+      );
+      if (toDelete.length > 0) {
+        diff.constraints.uniques.delete = toDelete;
+      }
+      if (toCreate.length > 0) {
+        diff.constraints.uniques.create = toCreate;
+      }
     }
 
     const oldIndexes = this.filterIndexesToKnownColumns(

--- a/src/engines/knex/utils/migration/sql-dialect.ts
+++ b/src/engines/knex/utils/migration/sql-dialect.ts
@@ -251,6 +251,23 @@ export function generateDropIndexSQL(
   }
 }
 
+export function generateDropUniqueSQL(
+  tableName: string,
+  constraintName: string,
+  dbType: 'mysql' | 'postgres',
+): string {
+  const table = quoteIdentifier(tableName, dbType);
+  const constraint = quoteIdentifier(constraintName, dbType);
+
+  switch (dbType) {
+    case 'postgres':
+      return `ALTER TABLE ${table} DROP CONSTRAINT ${constraint}`;
+    case 'mysql':
+    default:
+      return `ALTER TABLE ${table} DROP INDEX ${constraint}`;
+  }
+}
+
 export function generateAddIndexSQL(
   tableName: string,
   indexName: string,

--- a/src/engines/knex/utils/migration/sql-diff-generator.ts
+++ b/src/engines/knex/utils/migration/sql-diff-generator.ts
@@ -10,6 +10,7 @@ import {
   generateModifyColumnSQL,
   generateAddIndexSQL,
   generateDropIndexSQL,
+  generateDropUniqueSQL,
   generateDropColumnSQL,
   generateDropForeignKeySQL,
 } from './sql-dialect';
@@ -190,6 +191,26 @@ export async function generateSQLFromDiff(
       );
     }
   };
+  const findExistingUniqueNames = async (cols: string[]): Promise<string[]> => {
+    try {
+      const current = await getCurrentDatabaseSchema(knex, tableName);
+      const expected = cols.map((column) => column.toLowerCase());
+      return current.uniques
+        .filter(
+          (unique) =>
+            unique.columns.length === expected.length &&
+            unique.columns.every(
+              (column, position) => column.toLowerCase() === expected[position],
+            ),
+        )
+        .map((unique) => unique.name)
+        .filter(Boolean);
+    } catch (error) {
+      throw new Error(
+        `Cannot safely plan unique removal for ${tableName}(${cols.join(', ')}): ${getErrorMessage(error)}`,
+      );
+    }
+  };
   if (tableDiff.update) {
     sqlStatements.push(
       generateRenameTableSQL(
@@ -331,6 +352,21 @@ export async function generateSQLFromDiff(
     logger.log(
       `  Added UNIQUE constraint ${constraintName} on (${uniqueGroup.join(', ')})`,
     );
+  }
+  for (const uniqueGroup of ensureArray(constraintDiff.uniques?.delete) || []) {
+    const columns = Array.isArray(uniqueGroup)
+      ? uniqueGroup
+      : uniqueGroup?.value || [];
+    if (columns.length === 0) continue;
+    const existingConstraintNames = await findExistingUniqueNames(columns);
+    for (const constraintName of existingConstraintNames) {
+      sqlStatements.push(
+        generateDropUniqueSQL(activeTableName, constraintName, dbType),
+      );
+      logger.log(
+        `  Dropped UNIQUE constraint ${constraintName} (columns: ${columns.join(', ')})`,
+      );
+    }
   }
   for (const uniqueGroup of ensureArray(constraintDiff.uniques?.update) || []) {
     const columns = uniqueGroup.map((col: string) => qt(col)).join(', ');

--- a/test/domain/runtime-schema-gaps.spec.ts
+++ b/test/domain/runtime-schema-gaps.spec.ts
@@ -387,6 +387,42 @@ describe('SQL schema diff identity normalization', () => {
       rename: [],
     });
   });
+
+  it('emits a unique deletion when a table-level unique is removed', () => {
+    const service = new SqlSchemaDiffService({
+      knexService: {} as any,
+      metadataCacheService: {} as any,
+      queryBuilderService: {} as any,
+    });
+    const diff = {
+      columns: { create: [], update: [], delete: [], rename: [] },
+      constraints: {
+        uniques: { create: [], update: [], delete: [] },
+        indexes: { create: [], update: [], delete: [] },
+      },
+    };
+
+    (service as any).analyzeConstraintChanges(
+      {
+        name: 'ai_gateway_models',
+        columns: [],
+        relations: [],
+        uniques: [['modelName'], ['upstreamModel']],
+        indexes: [],
+      },
+      {
+        name: 'ai_gateway_models',
+        columns: [],
+        relations: [],
+        uniques: [['modelName']],
+        indexes: [],
+      },
+      diff,
+    );
+
+    expect(diff.constraints.uniques.delete).toEqual([['upstreamModel']]);
+    expect(diff.constraints.uniques.create).toEqual([]);
+  });
 });
 
 describe('Runtime inverse metadata attestation', () => {

--- a/test/knex/sql-schema-migration-on-delete.spec.ts
+++ b/test/knex/sql-schema-migration-on-delete.spec.ts
@@ -169,6 +169,45 @@ describe('resolveSqlRelationOnDelete', () => {
     );
   });
 
+  it('drops an existing PostgreSQL unique constraint by its physical name', async () => {
+    const knex = {
+      raw: vi.fn(async (query: string) => {
+        const normalizedQuery = query.toLowerCase();
+        if (normalizedQuery.includes('information_schema.columns')) {
+          return { rows: [] };
+        }
+        if (normalizedQuery.includes('table_constraints')) {
+          return { rows: [] };
+        }
+        if (normalizedQuery.includes('pg_index')) {
+          return {
+            rows: [
+              {
+                index_name: 'uq_ai_gateway_models_upstreamModel',
+                is_unique: true,
+                columns: ['upstreamModel'],
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      }),
+      schema: { hasColumn: vi.fn().mockResolvedValue(true) },
+      client: { config: { client: 'pg' } },
+    } as any;
+
+    const statements = await generateSQLFromDiff(
+      knex,
+      'ai_gateway_models',
+      { constraints: { uniques: { delete: [['upstreamModel']] } } },
+      'postgres',
+    );
+
+    expect(statements).toContain(
+      'ALTER TABLE "ai_gateway_models" DROP CONSTRAINT "uq_ai_gateway_models_upstreamModel"',
+    );
+  });
+
   it('fails planning before DDL when it cannot inspect an index slated for removal', async () => {
     const knex = {
       raw: vi.fn().mockRejectedValue(new Error('database connection lost')),


### PR DESCRIPTION
## Summary

- Fixed SQL runtime-schema planning when a table-level unique constraint is removed.
- Updated the server version to `2.2.17`.

## Verification

- `NODE_OPTIONS='--no-node-snapshot' yarn vitest run test/domain/runtime-schema-gaps.spec.ts test/knex/sql-schema-migration-on-delete.spec.ts`
- `yarn tsc --noEmit --pretty false`